### PR TITLE
feat: ユーザー新規登録・メール認証フロー実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,17 @@
 import React, { useEffect, useState } from 'react'
 import './App.css'
 import { LoginForm } from './features/auth/components/LoginForm'
-import { getCookie } from './shared/utils/cookie'
+import { RegisterForm } from './features/auth/components/RegisterForm'
+import { apiClient } from './shared/api/client'
 
 function App() {
   const [user, setUser] = useState<any>(null)
   const [loading, setLoading] = useState(true)
+  const [view, setView] = useState<'login' | 'register'>('login')
 
   const checkAuth = async () => {
     try {
-      const res = await fetch('/api/user', {
-        headers: {
-          'Accept': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-        credentials: 'include',
-      })
+      const res = await apiClient('/api/user')
       if (res.ok) {
         const data = await res.json()
         setUser(data)
@@ -35,16 +31,9 @@ function App() {
   }, [])
 
   const handleLogout = async () => {
-    const xsrfToken = getCookie('XSRF-TOKEN')
     try {
-      await fetch('/api/logout', {
+      await apiClient('/api/logout', {
         method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-          ...(xsrfToken ? { 'X-XSRF-TOKEN': xsrfToken } : {}),
-        },
-        credentials: 'include',
       })
       setUser(null)
     } catch (err) {
@@ -73,7 +62,22 @@ function App() {
       ) : (
         <div>
           <p>ログインしていません。</p>
-          <LoginForm onLoginSuccess={(u) => setUser(u)} />
+          {view === 'login' ? (
+            <div>
+              <LoginForm onLoginSuccess={(u) => setUser(u)} />
+              <button
+                onClick={() => setView('register')}
+                style={{ marginTop: '10px', backgroundColor: 'transparent', color: '#007bff', border: 'none', cursor: 'pointer', textDecoration: 'underline' }}
+              >
+                新規登録はこちら
+              </button>
+            </div>
+          ) : (
+            <RegisterForm
+              onRegisterSuccess={(u) => setUser(u)}
+              onSwitchToLogin={() => setView('login')}
+            />
+          )}
         </div>
       )}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,11 +43,11 @@ function App() {
   }
 
   if (loading) {
-    return <div style={{ padding: 20 }}>読み込み中...</div>
+    return <div className="p-5">読み込み中...</div>
   }
 
   return (
-    <div style={{ padding: 20 }}>
+    <div className="p-5">
       <h1>Shifty 認証テスト</h1>
 
       {user ? (
@@ -55,7 +55,7 @@ function App() {
           <p>ログイン中: {user.name} ({user.email})</p>
           <button
             onClick={handleLogout}
-            style={{ padding: '8px 16px', cursor: 'pointer' }}
+            className="px-4 py-2 cursor-pointer"
           >
             ログアウト
           </button>
@@ -68,7 +68,7 @@ function App() {
               <LoginForm onLoginSuccess={(u) => setUser(u)} />
               <button
                 onClick={() => setView('register')}
-                style={{ marginTop: '10px', backgroundColor: 'transparent', color: '#007bff', border: 'none', cursor: 'pointer', textDecoration: 'underline' }}
+                className="mt-2.5 bg-transparent text-blue-500 border-none cursor-pointer underline"
               >
                 新規登録はこちら
               </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from 'react'
 import './App.css'
 import { LoginForm } from './features/auth/components/LoginForm'
 import { RegisterForm } from './features/auth/components/RegisterForm'
+import type { User } from './features/auth/types'
 import { apiClient } from './shared/api/client'
 
 function App() {
-  const [user, setUser] = useState<any>(null)
+  const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
   const [view, setView] = useState<'login' | 'register'>('login')
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,22 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import './App.css'
 import { LoginForm } from './features/auth/components/LoginForm'
 import { RegisterForm } from './features/auth/components/RegisterForm'
+import { VerifyEmailPage } from './features/auth/components/VerifyEmailPage'
 import type { User } from './features/auth/types'
 import { apiClient } from './shared/api/client'
+
+interface VerifyParams {
+  verifyUrl: string;
+}
 
 function App() {
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
-  const [view, setView] = useState<'login' | 'register'>('login')
+  const [view, setView] = useState<'login' | 'register' | 'verify'>('login')
+  const [verifyParams, setVerifyParams] = useState<VerifyParams | null>(null)
 
-  const checkAuth = async () => {
+  const fetchCurrentUser = async () => {
     try {
       const res = await apiClient('/api/user')
       if (res.ok) {
@@ -20,7 +26,7 @@ function App() {
         setUser(null)
       }
     } catch (err) {
-      console.error('Auth check failed', err)
+      console.error('Failed to fetch current user', err)
       setUser(null)
     } finally {
       setLoading(false)
@@ -28,7 +34,16 @@ function App() {
   }
 
   useEffect(() => {
-    checkAuth()
+    // メール認証リンクのクエリパラメータを検知
+    const params = new URLSearchParams(window.location.search)
+    const verifyPath = params.get('verify_path')
+
+    if (verifyPath) {
+      setVerifyParams({ verifyUrl: verifyPath })
+      setView('verify')
+    }
+
+    fetchCurrentUser()
   }, [])
 
   const handleLogout = async () => {
@@ -44,6 +59,22 @@ function App() {
 
   if (loading) {
     return <div className="p-5">読み込み中...</div>
+  }
+
+  // メール認証ページ
+  if (view === 'verify' && verifyParams) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <VerifyEmailPage
+          {...verifyParams}
+          onVerified={() => {
+            setView('login')
+            setVerifyParams(null)
+            fetchCurrentUser()
+          }}
+        />
+      </div>
+    )
   }
 
   return (
@@ -75,7 +106,6 @@ function App() {
             </div>
           ) : (
             <RegisterForm
-              onRegisterSuccess={(u) => setUser(u)}
               onSwitchToLogin={() => setView('login')}
             />
           )}

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -8,3 +8,39 @@ export const getCsrfCookie = async (): Promise<void> => {
     method: 'GET',
   });
 };
+
+/**
+ * メールアドレスを認証する
+ * @param verifyUrl - Laravel から送られた認証URL（絶対URLまたはパス）
+ */
+export const verifyEmail = async (verifyUrl: string): Promise<void> => {
+  const response = await apiClient(verifyUrl, {
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error((data as { message?: string }).message ?? 'メール認証に失敗しました');
+  }
+};
+
+/**
+ * 確認メールを再送する
+ * @returns 'sent' | 'already-verified'
+ */
+export const resendVerificationEmail = async (): Promise<'sent' | 'already-verified'> => {
+  const response = await apiClient('/api/email/verification-notification', {
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error((data as { message?: string }).message ?? '確認メールの再送に失敗しました');
+  }
+
+  const data = await response.json().catch(() => ({}));
+  if ((data as { status?: string }).status === 'already-verified') {
+    return 'already-verified';
+  }
+  return 'sent';
+};

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '../../../shared/api/client';
+
+/**
+ * CSRFクッキーを取得する
+ */
+export const getCsrfCookie = async (): Promise<void> => {
+  await apiClient('/sanctum/csrf-cookie', {
+    method: 'GET',
+  });
+};

--- a/src/features/auth/components/EmailVerificationPending.tsx
+++ b/src/features/auth/components/EmailVerificationPending.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { resendVerificationEmail } from '../api/auth';
+
+interface EmailVerificationPendingProps {
+  email: string;
+}
+
+export const EmailVerificationPending: React.FC<EmailVerificationPendingProps> = ({ email }) => {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
+
+  const handleResend = async () => {
+    setStatus('sending');
+    try {
+      const result = await resendVerificationEmail();
+      if (result === 'already-verified' || result === 'sent') {
+        setStatus('sent');
+      } else {
+        setStatus('error');
+      }
+    } catch (err) {
+      console.error('再送エラー:', err);
+      setStatus('error');
+    }
+  };
+
+  return (
+    <div className="max-w-[400px] w-full p-8 border border-gray-300 rounded-lg bg-white">
+      <div className="text-center mb-6">
+        <div className="flex justify-center mb-4">
+          <svg
+            className="w-16 h-16 text-green-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+
+            
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+        </div>
+        <h2 className="text-xl font-bold mb-2">メール認証をお願いします</h2>
+        <p className="text-sm text-gray-600">
+          <span className="font-medium text-gray-900">{email}</span> に確認メールを送信しました。
+        </p>
+      </div>
+
+      <div className="bg-gray-50 rounded-lg p-4 mb-6 text-sm text-gray-700 space-y-1">
+        <p>1. 受信トレイを確認してください。</p>
+        <p>2. メール内の「メールアドレスを確認する」リンクをクリックしてください。</p>
+        <p>3. 認証が完了するとログインできます。</p>
+      </div>
+
+      {status === 'sent' && (
+        <p className="text-sm text-green-600 text-center mb-4">確認メールを再送しました。</p>
+      )}
+      {status === 'error' && (
+        <p className="text-sm text-red-500 text-center mb-4">再送に失敗しました。しばらくしてから再試行してください。</p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleResend}
+        disabled={status === 'sending'}
+        className="w-full py-2.5 px-4 border border-gray-300 rounded text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {status === 'sending' ? '送信中...' : 'メールを再送する'}
+      </button>
+    </div>
+  );
+};

--- a/src/features/auth/components/EmailVerificationPending.tsx
+++ b/src/features/auth/components/EmailVerificationPending.tsx
@@ -34,14 +34,12 @@ export const EmailVerificationPending: React.FC<EmailVerificationPendingProps> =
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <path
-
-            
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-            />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+              />
           </svg>
         </div>
         <h2 className="text-xl font-bold mb-2">メール認証をお願いします</h2>

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { apiClient } from '../../../shared/api/client';
+import { getCsrfCookie } from '../api/auth';
 import type { User } from '../types';
 
 interface LoginFormProps {
@@ -19,10 +20,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
 
     try {
       // 1. CSRF Cookieの取得
-      await fetch('/sanctum/csrf-cookie', {
-        method: 'GET',
-        credentials: 'include',
-      });
+      await getCsrfCookie();
 
       // 2. ログイン実行（204 No Content が返るためボディなし）
       const response = await apiClient('/api/login', {

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -28,20 +28,31 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
         body: JSON.stringify({ email, password }),
       });
 
-      if (response.ok) {
-        // ログイン成功 → ユーザー情報を取得
-        const userRes = await apiClient('/api/user');
-        if (userRes.ok) {
-          const userData = await userRes.json();
-          onLoginSuccess(userData);
-        } else {
-          setError('ユーザー情報の取得に失敗しました。');
-        }
-      } else {
-        const data = await response.json();
+      if (!response.ok) {
+        // レスポンスのパース失敗も考慮
+        const data = await response.json().catch(() => ({}));
         setError(data.message || 'ログインに失敗しました。');
+        return; // 早期リターンで後続処理を止める
       }
+
+      // 3. ユーザー情報を取得
+      const userRes = await apiClient('/api/user');
+
+      if (!userRes.ok) {
+        setError('ユーザー情報の取得に失敗しました。');
+        return;
+      }
+
+      // パース失敗をキャッチ → 外側の catch に委譲しない
+      const userData = await userRes.json().catch(() => null);
+      if (!userData) {
+        setError('ユーザー情報の解析に失敗しました。');
+        return;
+      }
+
+      onLoginSuccess(userData);
     } catch (err) {
+      // 通信エラー（fetch自体の失敗）のみここに到達させる
       setError('通信エラーが発生しました。');
       console.error(err);
     } finally {

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { getCookie } from '../../../shared/utils/cookie';
+import { apiClient } from '../../../shared/api/client';
 
 interface LoginFormProps {
   onLoginSuccess: (user: any) => void;
@@ -23,18 +23,9 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
         credentials: 'include',
       });
 
-      const xsrfToken = getCookie('XSRF-TOKEN');
-
       // 2. ログイン実行
-      const response = await fetch('/api/login', {
+      const response = await apiClient('/api/login', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-          ...(xsrfToken ? { 'X-XSRF-TOKEN': xsrfToken } : {}),
-        },
-        credentials: 'include',
         body: JSON.stringify({ email, password }),
       });
 

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { apiClient } from '../../../shared/api/client';
+import type { User } from '../types';
 
 interface LoginFormProps {
-  onLoginSuccess: (user: any) => void;
+  onLoginSuccess: (user: User) => void;
 }
 
 export const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -23,17 +23,23 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
         credentials: 'include',
       });
 
-      // 2. ログイン実行
+      // 2. ログイン実行（204 No Content が返るためボディなし）
       const response = await apiClient('/api/login', {
         method: 'POST',
         body: JSON.stringify({ email, password }),
       });
 
-      const data = await response.json();
-
       if (response.ok) {
-        onLoginSuccess(data.user);
+        // ログイン成功 → ユーザー情報を取得
+        const userRes = await apiClient('/api/user');
+        if (userRes.ok) {
+          const userData = await userRes.json();
+          onLoginSuccess(userData);
+        } else {
+          setError('ユーザー情報の取得に失敗しました。');
+        }
       } else {
+        const data = await response.json();
         setError(data.message || 'ログインに失敗しました。');
       }
     } catch (err) {

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -61,42 +61,36 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
   };
 
   return (
-    <div style={{ border: '1px solid #ccc', padding: '20px', borderRadius: '8px', maxWidth: '400px' }}>
-      <h2>ログイン</h2>
+    <div className="max-w-[400px] p-5 border border-gray-300 rounded-lg">
+      <h2 className="text-xl font-bold mb-4">ログイン</h2>
       <form onSubmit={handleSubmit}>
-        <div style={{ marginBottom: '10px' }}>
-          <label style={{ display: 'block' }}>メールアドレス:</label>
+        <div className="mb-2.5">
+          <label className="block mb-1">メールアドレス:</label>
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            style={{ width: '100%', padding: '8px' }}
+            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />
         </div>
-        <div style={{ marginBottom: '10px' }}>
-          <label style={{ display: 'block' }}>パスワード:</label>
+        <div className="mb-2.5">
+          <label className="block mb-1">パスワード:</label>
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            style={{ width: '100%', padding: '8px' }}
+            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />
         </div>
-        {error && <p style={{ color: 'red' }}>{error}</p>}
+        {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
         <button
           type="submit"
           disabled={loading}
-          style={{
-            width: '100%',
-            padding: '10px',
-            backgroundColor: loading ? '#ccc' : '#007bff',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: loading ? 'not-allowed' : 'pointer'
-          }}
+          className={`w-full py-2.5 rounded-md text-white border-none mt-4 ${
+            loading ? 'bg-gray-300 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700 cursor-pointer'
+          }`}
         >
           {loading ? '送信中...' : 'ログイン'}
         </button>

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { apiClient } from '../../../shared/api/client';
+import type { User } from '../types';
 
 interface RegisterFormProps {
-  onRegisterSuccess: (user: any) => void;
+  onRegisterSuccess: (user: User) => void;
   onSwitchToLogin: () => void;
 }
 

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -1,20 +1,26 @@
 import React, { useState } from 'react';
 import { apiClient } from '../../../shared/api/client';
 import { getCsrfCookie } from '../api/auth';
-import type { User } from '../types';
+import { EmailVerificationPending } from './EmailVerificationPending';
 
 interface RegisterFormProps {
-  onRegisterSuccess: (user: User) => void;
   onSwitchToLogin: () => void;
 }
 
-export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegisterSuccess, onSwitchToLogin }) => {
+export const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin }) => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [passwordConfirmation, setPasswordConfirmation] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [verificationPending, setVerificationPending] = useState(false);
+  const [registeredEmail, setRegisteredEmail] = useState('');
+
+  // 登録成功後に認証待ち画面を表示
+  if (verificationPending) {
+    return <EmailVerificationPending email={registeredEmail} />;
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,22 +49,9 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegisterSuccess, o
         return; // 早期リターンで後続処理を止める
       }
 
-      // 3. ユーザー情報を取得
-      const userRes = await apiClient('/api/user');
-
-      if (!userRes.ok) {
-        setError('ユーザー情報の取得に失敗しました。');
-        return;
-      }
-
-      // パース失敗をキャッチ → 外側の catch に委譲しない
-      const userData = await userRes.json().catch(() => null);
-      if (!userData) {
-        setError('ユーザー情報の解析に失敗しました。');
-        return;
-      }
-
-      onRegisterSuccess(userData);
+      // 登録成功 → メール認証待ち画面へ
+      setRegisteredEmail(email);
+      setVerificationPending(true);
     } catch (err) {
       // 通信エラー（fetch自体の失敗）のみここに到達させる
       setError('通信エラーが発生しました。');

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -36,19 +36,31 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegisterSuccess, o
         }),
       });
 
-      if (response.ok) {
-        // 登録成功時は通常そのままログイン状態になる
-        // 本来ならユーザー情報を取得するAPIを叩くのが確実
-        const userRes = await apiClient('/api/user');
-        if (userRes.ok) {
-            const userData = await userRes.json();
-            onRegisterSuccess(userData);
-        }
-      } else {
-        const data = await response.json();
+      if (!response.ok) {
+        // レスポンスのパース失敗も考慮
+        const data = await response.json().catch(() => ({}));
         setError(data.message || '登録に失敗しました。');
+        return; // 早期リターンで後続処理を止める
       }
+
+      // 3. ユーザー情報を取得
+      const userRes = await apiClient('/api/user');
+
+      if (!userRes.ok) {
+        setError('ユーザー情報の取得に失敗しました。');
+        return;
+      }
+
+      // パース失敗をキャッチ → 外側の catch に委譲しない
+      const userData = await userRes.json().catch(() => null);
+      if (!userData) {
+        setError('ユーザー情報の解析に失敗しました。');
+        return;
+      }
+
+      onRegisterSuccess(userData);
     } catch (err) {
+      // 通信エラー（fetch自体の失敗）のみここに到達させる
       setError('通信エラーが発生しました。');
       console.error(err);
     } finally {
@@ -57,7 +69,6 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegisterSuccess, o
   };
 
   return (
-    <div style={{ border: '1px solid #ccc', padding: '20px', borderRadius: '8px', maxWidth: '400px' }}>
     <div className="max-w-sm border border-gray-300 p-5 rounded-lg">
       <h2>新規登録</h2>
       <form onSubmit={handleSubmit}>
@@ -115,6 +126,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegisterSuccess, o
           type="button"
           onClick={onSwitchToLogin}
           className="w-full py-2.5 bg-transparent text-blue-500 border-none cursor-pointer underline"
+        >
           ログインはこちら
         </button>
       </form>

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -69,66 +69,73 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegisterSuccess, o
   };
 
   return (
-    <div className="max-w-sm border border-gray-300 p-5 rounded-lg">
-      <h2>新規登録</h2>
-      <form onSubmit={handleSubmit}>
-        <div className="mb-2.5">
-          <label className="block mb-1">名前:</label>
+    <div className="max-w-[400px] w-full p-8 border border-gray-300 rounded-lg bg-white">
+      <h2 className="text-xl font-bold mb-8 text-center">新規登録</h2>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <label className="block mb-2 text-sm font-medium">名前</label>
           <input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full p-2.5 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-green-500"
             required
           />
         </div>
-        <div className="mb-2.5">
-          <label className="block mb-1">メールアドレス:</label>
+        <div>
+          <label className="block mb-2 text-sm font-medium">メールアドレス</label>
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full p-2.5 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-green-500"
             required
           />
         </div>
-        <div className="mb-2.5">
-          <label className="block mb-1">パスワード:</label>
+        <div>
+          <label className="block mb-2 text-sm font-medium">パスワード</label>
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full p-2.5 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-green-500"
             required
           />
         </div>
-        <div className="mb-2.5">
-          <label className="block mb-1">パスワード(確認):</label>
+        <div>
+          <label className="block mb-2 text-sm font-medium">パスワード(確認)</label>
           <input
             type="password"
             value={passwordConfirmation}
             onChange={(e) => setPasswordConfirmation(e.target.value)}
-            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full p-2.5 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-green-500"
             required
           />
         </div>
-        {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
-        <button
-          type="submit"
-          disabled={loading}
-          className={`w-full py-2.5 rounded-md text-white border-none mb-2.5 ${
-            loading ? 'bg-gray-300 cursor-not-allowed' : 'bg-green-600 hover:bg-green-700 cursor-pointer'
-          }`}
-        >
-          {loading ? '送信中...' : '登録'}
-        </button>
-        <button
-          type="button"
-          onClick={onSwitchToLogin}
-          className="w-full py-2.5 bg-transparent text-blue-500 border-none cursor-pointer underline"
-        >
-          ログインはこちら
-        </button>
+
+        {error && <p className="text-sm text-red-500 mt-2">{error}</p>}
+
+        <div className="pt-2">
+          <button
+            type="submit"
+            disabled={loading}
+            className={`w-full py-3 rounded-md text-white border-none font-bold ${
+              loading ? 'bg-gray-300 cursor-not-allowed' : 'bg-green-600 hover:bg-green-700 cursor-pointer'
+            }`}
+          >
+            {loading ? '送信中...' : '登録する'}
+          </button>
+        </div>
+
+        <div className="text-center">
+          <button
+            type="button"
+            onClick={onSwitchToLogin}
+            className="text-sm text-blue-500 hover:underline bg-transparent border-none cursor-pointer"
+          >
+            ログインはこちら
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -58,78 +58,63 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegisterSuccess, o
 
   return (
     <div style={{ border: '1px solid #ccc', padding: '20px', borderRadius: '8px', maxWidth: '400px' }}>
+    <div className="max-w-sm border border-gray-300 p-5 rounded-lg">
       <h2>新規登録</h2>
       <form onSubmit={handleSubmit}>
-        <div style={{ marginBottom: '10px' }}>
-          <label style={{ display: 'block' }}>名前:</label>
+        <div className="mb-2.5">
+          <label className="block mb-1">名前:</label>
           <input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            style={{ width: '100%', padding: '8px' }}
+            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />
         </div>
-        <div style={{ marginBottom: '10px' }}>
-          <label style={{ display: 'block' }}>メールアドレス:</label>
+        <div className="mb-2.5">
+          <label className="block mb-1">メールアドレス:</label>
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            style={{ width: '100%', padding: '8px' }}
+            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />
         </div>
-        <div style={{ marginBottom: '10px' }}>
-          <label style={{ display: 'block' }}>パスワード:</label>
+        <div className="mb-2.5">
+          <label className="block mb-1">パスワード:</label>
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            style={{ width: '100%', padding: '8px' }}
+            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />
         </div>
-        <div style={{ marginBottom: '10px' }}>
-          <label style={{ display: 'block' }}>パスワード(確認):</label>
+        <div className="mb-2.5">
+          <label className="block mb-1">パスワード(確認):</label>
           <input
             type="password"
             value={passwordConfirmation}
             onChange={(e) => setPasswordConfirmation(e.target.value)}
-            style={{ width: '100%', padding: '8px' }}
+            className="w-full p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />
         </div>
-        {error && <p style={{ color: 'red' }}>{error}</p>}
+        {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
         <button
           type="submit"
           disabled={loading}
-          style={{
-            width: '100%',
-            padding: '10px',
-            backgroundColor: loading ? '#ccc' : '#28a745',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: loading ? 'not-allowed' : 'pointer',
-            marginBottom: '10px'
-          }}
+          className={`w-full py-2.5 rounded-md text-white border-none mb-2.5 ${
+            loading ? 'bg-gray-300 cursor-not-allowed' : 'bg-green-600 hover:bg-green-700 cursor-pointer'
+          }`}
         >
           {loading ? '送信中...' : '登録'}
         </button>
         <button
           type="button"
           onClick={onSwitchToLogin}
-          style={{
-            width: '100%',
-            padding: '10px',
-            backgroundColor: 'transparent',
-            color: '#007bff',
-            border: 'none',
-            cursor: 'pointer',
-            textDecoration: 'underline'
-          }}
-        >
+          className="w-full py-2.5 bg-transparent text-blue-500 border-none cursor-pointer underline"
           ログインはこちら
         </button>
       </form>

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { apiClient } from '../../../shared/api/client';
+import { getCsrfCookie } from '../api/auth';
 import type { User } from '../types';
 
 interface RegisterFormProps {
@@ -22,10 +23,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegisterSuccess, o
 
     try {
       // 1. CSRF Cookieの取得
-      await fetch('/sanctum/csrf-cookie', {
-        method: 'GET',
-        credentials: 'include',
-      });
+      await getCsrfCookie();
 
       // 2. 登録実行
       const response = await apiClient('/api/register', {

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import { apiClient } from '../../../shared/api/client';
+
+interface RegisterFormProps {
+  onRegisterSuccess: (user: any) => void;
+  onSwitchToLogin: () => void;
+}
+
+export const RegisterForm: React.FC<RegisterFormProps> = ({ onRegisterSuccess, onSwitchToLogin }) => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirmation, setPasswordConfirmation] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      // 1. CSRF Cookieの取得
+      await fetch('/sanctum/csrf-cookie', {
+        method: 'GET',
+        credentials: 'include',
+      });
+
+      // 2. 登録実行
+      const response = await apiClient('/api/register', {
+        method: 'POST',
+        body: JSON.stringify({
+          name,
+          email,
+          password,
+          password_confirmation: passwordConfirmation,
+        }),
+      });
+
+      if (response.ok) {
+        // 登録成功時は通常そのままログイン状態になる
+        // 本来ならユーザー情報を取得するAPIを叩くのが確実
+        const userRes = await apiClient('/api/user');
+        if (userRes.ok) {
+            const userData = await userRes.json();
+            onRegisterSuccess(userData);
+        }
+      } else {
+        const data = await response.json();
+        setError(data.message || '登録に失敗しました。');
+      }
+    } catch (err) {
+      setError('通信エラーが発生しました。');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '20px', borderRadius: '8px', maxWidth: '400px' }}>
+      <h2>新規登録</h2>
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: '10px' }}>
+          <label style={{ display: 'block' }}>名前:</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            style={{ width: '100%', padding: '8px' }}
+            required
+          />
+        </div>
+        <div style={{ marginBottom: '10px' }}>
+          <label style={{ display: 'block' }}>メールアドレス:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            style={{ width: '100%', padding: '8px' }}
+            required
+          />
+        </div>
+        <div style={{ marginBottom: '10px' }}>
+          <label style={{ display: 'block' }}>パスワード:</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            style={{ width: '100%', padding: '8px' }}
+            required
+          />
+        </div>
+        <div style={{ marginBottom: '10px' }}>
+          <label style={{ display: 'block' }}>パスワード(確認):</label>
+          <input
+            type="password"
+            value={passwordConfirmation}
+            onChange={(e) => setPasswordConfirmation(e.target.value)}
+            style={{ width: '100%', padding: '8px' }}
+            required
+          />
+        </div>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            width: '100%',
+            padding: '10px',
+            backgroundColor: loading ? '#ccc' : '#28a745',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            marginBottom: '10px'
+          }}
+        >
+          {loading ? '送信中...' : '登録'}
+        </button>
+        <button
+          type="button"
+          onClick={onSwitchToLogin}
+          style={{
+            width: '100%',
+            padding: '10px',
+            backgroundColor: 'transparent',
+            color: '#007bff',
+            border: 'none',
+            cursor: 'pointer',
+            textDecoration: 'underline'
+          }}
+        >
+          ログインはこちら
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/src/features/auth/components/VerifyEmailPage.tsx
+++ b/src/features/auth/components/VerifyEmailPage.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { verifyEmail } from '../api/auth';
+
+interface VerifyEmailPageProps {
+  verifyUrl: string;
+  onVerified: () => void;
+}
+
+export const VerifyEmailPage: React.FC<VerifyEmailPageProps> = ({
+  verifyUrl,
+  onVerified,
+}) => {
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    verifyEmail(verifyUrl)
+      .then(() => {
+        // URLからクエリパラメータを除去
+        window.history.replaceState({}, '', '/');
+        setStatus('success');
+        // 2秒後にダッシュボードへ
+        setTimeout(() => onVerified(), 2000);
+      })
+      .catch((err: Error) => {
+        setErrorMessage(err.message);
+        setStatus('error');
+      });
+  }, []);
+
+  return (
+    <div className="max-w-[400px] w-full p-8 border border-gray-300 rounded-lg bg-white text-center">
+      {status === 'loading' && (
+        <>
+          <div className="flex justify-center mb-4">
+            <div className="w-10 h-10 border-4 border-gray-200 border-t-green-500 rounded-full animate-spin" />
+          </div>
+          <p className="text-gray-600">メールアドレスを認証しています...</p>
+        </>
+      )}
+
+      {status === 'success' && (
+        <>
+          <div className="flex justify-center mb-4">
+            <svg className="w-16 h-16 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <h2 className="text-xl font-bold mb-2">認証が完了しました！</h2>
+          <p className="text-sm text-gray-600">ダッシュボードへ移動します...</p>
+        </>
+      )}
+
+      {status === 'error' && (
+        <>
+          <div className="flex justify-center mb-4">
+            <svg className="w-16 h-16 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </div>
+          <h2 className="text-xl font-bold mb-2">認証に失敗しました</h2>
+          <p className="text-sm text-red-500 mb-4">{errorMessage}</p>
+          <p className="text-sm text-gray-600">リンクの有効期限が切れているか、無効なリンクです。</p>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/features/auth/components/VerifyEmailPage.tsx
+++ b/src/features/auth/components/VerifyEmailPage.tsx
@@ -14,19 +14,19 @@ export const VerifyEmailPage: React.FC<VerifyEmailPageProps> = ({
   const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
-    verifyEmail(verifyUrl)
-      .then(() => {
-        // URLからクエリパラメータを除去
+    const verify = async () => {
+      try {
+        await verifyEmail(verifyUrl);
         window.history.replaceState({}, '', '/');
         setStatus('success');
-        // 2秒後にダッシュボードへ
         setTimeout(() => onVerified(), 2000);
-      })
-      .catch((err: Error) => {
+      } catch (err: any) {
         setErrorMessage(err.message);
         setStatus('error');
-      });
-  }, []);
+      }
+    };
+    verify();
+  }, []); // 認証は1回だけ実行
 
   return (
     <div className="max-w-[400px] w-full p-8 border border-gray-300 rounded-lg bg-white text-center">

--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  email_verified_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,0 +1,36 @@
+import { getCookie } from '../utils/cookie';
+
+/**
+ * APIリクエストのベースとなるクライアント
+ */
+export const apiClient = async (endpoint: string, options: RequestInit = {}) => {
+  const baseUrl = import.meta.env.VITE_API_URL || '';
+  
+  const xsrfToken = getCookie('XSRF-TOKEN');
+  
+  const defaultHeaders: Record<string, string> = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+    'X-Requested-With': 'XMLHttpRequest',
+  };
+
+  if (xsrfToken) {
+    defaultHeaders['X-XSRF-TOKEN'] = xsrfToken;
+  }
+
+  const response = await fetch(`${baseUrl}${endpoint}`, {
+    ...options,
+    headers: {
+      ...defaultHeaders,
+      ...options.headers,
+    },
+    // クッキー（Sanctum）を送信するために必要
+    credentials: 'include',
+  });
+
+  if (!response.ok && response.status !== 422) {
+    throw new Error(response.statusText);
+  }
+
+  return response;
+};

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -4,8 +4,6 @@ import { getCookie } from '../utils/cookie';
  * APIリクエストのベースとなるクライアント
  */
 export const apiClient = async (endpoint: string, options: RequestInit = {}) => {
-  const baseUrl = import.meta.env.VITE_API_URL || '';
-
   const xsrfToken = getCookie('XSRF-TOKEN');
 
   const defaultHeaders: Record<string, string> = {
@@ -18,7 +16,7 @@ export const apiClient = async (endpoint: string, options: RequestInit = {}) => 
     defaultHeaders['X-XSRF-TOKEN'] = xsrfToken;
   }
 
-  const response = await fetch(`${baseUrl}${endpoint}`, {
+  const response = await fetch(endpoint, {
     ...options,
     headers: {
       ...defaultHeaders,

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -5,9 +5,9 @@ import { getCookie } from '../utils/cookie';
  */
 export const apiClient = async (endpoint: string, options: RequestInit = {}) => {
   const baseUrl = import.meta.env.VITE_API_URL || '';
-  
+
   const xsrfToken = getCookie('XSRF-TOKEN');
-  
+
   const defaultHeaders: Record<string, string> = {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
@@ -27,10 +27,6 @@ export const apiClient = async (endpoint: string, options: RequestInit = {}) => 
     // クッキー（Sanctum）を送信するために必要
     credentials: 'include',
   });
-
-  if (!response.ok && response.status !== 422) {
-    throw new Error(response.statusText);
-  }
 
   return response;
 };


### PR DESCRIPTION
## PR概要

**ユーザー登録〜メール認証までの一連の画面とAPI連携を実装**

---

### 変更内容

**① 新規登録画面の実装**

- 登録フォームを実装
- 登録前にCSRFトークンを取得してからAPIに送信
- 登録成功後は自動でメール確認待ち画面に遷移

**② メール確認待ち画面の実装**

- 「確認メールを送信しました」と案内する画面を追加
- メールが届かない場合の再送機能も実装

**③ メール認証ページの実装**

```
メール内リンクをクリック
  → VerifyEmailPageに遷移
  → バックエンドに認証リクエスト送信
  → 成功 → ダッシュボードへ自動遷移
```

**④ ログインフローの整理**

```
CSRF取得 → ログイン → /api/userでユーザー情報取得
```
この順序を明確化し、認証状態の反映を確実にした

**⑤ API通信の共通処理の整理**

- `getCsrfCookie` / `verifyEmail` / `resendVerificationEmail` などを共通関数として切り出し
- 各画面から同じ処理を呼び出せる構成に整理

---