### PR TITLE
refactor: 認証フォームの型定義およびログインフローの整理

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,7 +99,9 @@ function App() {
           <p>ログインしていません。</p>
           {view === 'login' ? (
             <div className="space-y-4">
-              <LoginForm onLoginSuccess={(u) => setUser(u)} />
+              <LoginForm onLoginSuccess={() => {
+                void fetchCurrentUser()
+              }} />
               <Button
                 onClick={() => setView('register')}
                 variant="link"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,9 +99,7 @@ function App() {
           <p>ログインしていません。</p>
           {view === 'login' ? (
             <div className="space-y-4">
-              <LoginForm onLoginSuccess={() => {
-                void fetchCurrentUser()
-              }} />
+              <LoginForm onLoginSuccess={fetchCurrentUser} />
               <Button
                 onClick={() => setView('register')}
                 variant="link"

--- a/src/features/auth/components/EmailVerificationPending.tsx
+++ b/src/features/auth/components/EmailVerificationPending.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { CheckCircle2, Mail } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -12,11 +12,8 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { resendVerificationEmail } from '../api/auth';
 
-interface EmailVerificationPendingProps {
-  email: string;
-}
 
-export const EmailVerificationPending: React.FC<EmailVerificationPendingProps> = ({ email }) => {
+export const EmailVerificationPending = ({ email }: { email: string }) => {
   const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
 
   const handleResend = async () => {

--- a/src/features/auth/components/ForgotPasswordForm.tsx
+++ b/src/features/auth/components/ForgotPasswordForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -21,7 +21,7 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
   const [status, setStatus] = useState<'idle' | 'loading' | 'sent' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setStatus('loading');
     setError(null);

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { apiClient } from '../../../shared/api/client';
 import { getCsrfCookie } from '../api/auth';
-import type { User } from '../types';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -14,7 +13,7 @@ import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 
 interface LoginFormProps {
-  onLoginSuccess: (user: User) => void;
+  onLoginSuccess: () => void;
 }
 
 export const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
@@ -45,22 +44,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
         return; // 早期リターンで後続処理を止める
       }
 
-      // 3. ユーザー情報を取得
-      const userRes = await apiClient('/api/v1/user');
-
-      if (!userRes.ok) {
-        setError('ユーザー情報の取得に失敗しました。');
-        return;
-      }
-
-      // パース失敗をキャッチ → 外側の catch に委譲しない
-      const userData = await userRes.json().catch(() => null);
-      if (!userData) {
-        setError('ユーザー情報の解析に失敗しました。');
-        return;
-      }
-
-      onLoginSuccess(userData);
+      onLoginSuccess();
     } catch (err) {
       // 通信エラー（fetch自体の失敗）のみここに到達させる
       setError('通信エラーが発生しました。');

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { apiClient } from '../../../shared/api/client';
 import { getCsrfCookie } from '../api/auth';
 import { Button } from '@/components/ui/button';
@@ -16,13 +16,13 @@ interface LoginFormProps {
   onLoginSuccess: () => void;
 }
 
-export const LoginForm: React.FC<LoginFormProps> = ({ onLoginSuccess }) => {
+export const LoginForm = ({ onLoginSuccess }: LoginFormProps) => {
   const [email, setEmail] = useState('test@example.com');
   const [password, setPassword] = useState('password');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError(null);

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { apiClient } from '../../../shared/api/client';
 import { getCsrfCookie } from '../api/auth';
 import { EmailVerificationPending } from './EmailVerificationPending';
@@ -18,7 +18,7 @@ interface RegisterFormProps {
   onSwitchToLogin: () => void;
 }
 
-export const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin }) => {
+export const RegisterForm = ({ onSwitchToLogin }: RegisterFormProps) => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -33,7 +33,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin }) =
     return <EmailVerificationPending email={registeredEmail} />;
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError(null);

--- a/src/features/auth/components/ResetPasswordForm.tsx
+++ b/src/features/auth/components/ResetPasswordForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -23,7 +23,7 @@ export function ResetPasswordForm({ token, email, onSuccess }: ResetPasswordForm
   const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setStatus('loading');
     setError(null);

--- a/src/features/auth/components/VerifyEmailPage.tsx
+++ b/src/features/auth/components/VerifyEmailPage.tsx
@@ -44,35 +44,35 @@ export const VerifyEmailPage: React.FC<VerifyEmailPageProps> = ({
       </CardHeader>
       <Separator />
       <CardContent className="space-y-3">
-      {status === 'loading' && (
-        <>
-          <div className="flex justify-center">
-            <Loader2 className="size-10 animate-spin text-primary" />
-          </div>
-          <CardDescription>メールアドレスを認証しています...</CardDescription>
-        </>
-      )}
+        {status === 'loading' && (
+          <>
+            <div className="flex justify-center">
+              <Loader2 className="size-10 animate-spin text-primary" />
+            </div>
+            <CardDescription>メールアドレスを認証しています...</CardDescription>
+          </>
+        )}
 
-      {status === 'success' && (
-        <>
-          <div className="flex justify-center">
-            <CheckCircle2 className="size-14 text-primary" />
-          </div>
-          <p className="text-lg font-semibold">認証が完了しました</p>
-          <CardDescription>ダッシュボードへ移動します...</CardDescription>
-        </>
-      )}
+        {status === 'success' && (
+          <>
+            <div className="flex justify-center">
+              <CheckCircle2 className="size-14 text-primary" />
+            </div>
+            <p className="text-lg font-semibold">認証が完了しました</p>
+            <CardDescription>ダッシュボードへ移動します...</CardDescription>
+          </>
+        )}
 
-      {status === 'error' && (
-        <>
-          <div className="flex justify-center">
-            <XCircle className="size-14 text-destructive" />
-          </div>
-          <p className="text-lg font-semibold">認証に失敗しました</p>
-          <p className="text-sm text-destructive">{errorMessage}</p>
-          <CardDescription>リンクの有効期限が切れているか、無効なリンクです。</CardDescription>
-        </>
-      )}
+        {status === 'error' && (
+          <>
+            <div className="flex justify-center">
+              <XCircle className="size-14 text-destructive" />
+            </div>
+            <p className="text-lg font-semibold">認証に失敗しました</p>
+            <p className="text-sm text-destructive">{errorMessage}</p>
+            <CardDescription>リンクの有効期限が切れているか、無効なリンクです。</CardDescription>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/features/auth/components/VerifyEmailPage.tsx
+++ b/src/features/auth/components/VerifyEmailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CheckCircle2, Loader2, XCircle } from 'lucide-react';
 import {
   Card,
@@ -10,14 +10,12 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { verifyEmail } from '../api/auth';
 
-interface VerifyEmailPageProps {
-  verifyUrl: string;
-  onVerified: () => void;
-}
-
-export const VerifyEmailPage: React.FC<VerifyEmailPageProps> = ({
+export const VerifyEmailPage = ({
   verifyUrl,
   onVerified,
+}: {
+  verifyUrl: string;
+  onVerified: () => void;
 }) => {
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
   const [errorMessage, setErrorMessage] = useState('');

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -10,15 +10,15 @@ export function ResetPasswordPage() {
   const token = tokenFromPath;
   const emailFromQuery = searchParams.get('email');
 
-if (token && emailFromQuery) {
-  return (
-    <ResetPasswordForm
-      token={token}
-      email={emailFromQuery}
-      onSuccess={() => navigate(PATHS.LOGIN)}
-    />
-  );
-}
+  if (token && emailFromQuery) {
+    return (
+      <ResetPasswordForm
+        token={token}
+        email={emailFromQuery}
+        onSuccess={() => navigate(PATHS.LOGIN)}
+      />
+    );
+  }
 
-return <ForgotPasswordForm onSwitchToLogin={() => navigate(PATHS.LOGIN)} />;
+  return <ForgotPasswordForm onSwitchToLogin={() => navigate(PATHS.LOGIN)} />;
 }


### PR DESCRIPTION
概要
認証関連フォームの型定義を統一し、ログイン処理におけるデータ取得の責務を整理することで、コードの保守性と一貫性を向上させた。

変更内容
| 項目 | 内容 |
| :--- | :--- |
| イベント型の統一 | `LoginForm` 等の各フォームにおいて、イベントハンドラの型を `FormEvent` に標準化した。 |
| ログインフローの変更 | `LoginForm` の成功時コールバックからユーザー情報の渡却を廃止し、親コンポーネントでの取得へ変更した。 |
| コンポーネント定義の刷新 | `React.FC` を廃止し、引数への直接型付けに変更した。 |

変更の目的
各認証フォームにおける型定義のばらつきを解消し、React の推奨されるコンポーネントの型付けパターンに準拠するためである。また、ログイン成功後のユーザー情報取得を親コンポーネントに一任することで、コンポーネント間の責務を明確化し、ログインフローを簡素化することを意図している。