### PR TITLE
feat: [13.1] TanStack Query 導入・認証ユーザー取得・Devtools 整備

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,5 @@
 # 本番時: 別オリジンになるため絶対 URL を指定する（例: https://api.shifty.example.com）
 VITE_API_BASE_URL=
 
-# デバッグモード（true のとき React Query Devtools を表示）
+# デバッグモード（開発環境（DEV）かつ true のとき React Query Devtools を表示）
 VITE_DEBUG=false

--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,5 @@
 # 本番時: 別オリジンになるため絶対 URL を指定する（例: https://api.shifty.example.com）
 VITE_API_BASE_URL=
 
-# デバッグモード（開発環境でのみ有効にすることを推奨）
+# デバッグモード（true のとき React Query Devtools を表示）
 VITE_DEBUG=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.2.2",
+        "@tanstack/react-query-devtools": "^5.95.2",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -792,6 +793,17 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.95.2.tgz",
+      "integrity": "sha512-QfaoqBn9uAZ+ICkA8brd1EHj+qBF6glCFgt94U8XP5BT6ppSsDBI8IJ00BU+cAGjQzp6wcKJL2EmRYvxy0TWIg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.95.2",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
@@ -805,6 +817,24 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.95.2.tgz",
+      "integrity": "sha512-AFQFmbznVkbtfpx8VJ2DylW17wWagQel/qLstVLkYmNRo2CmJt3SNej5hvl6EnEeljJIdC3BTB+W7HZtpsH+3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.95.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.95.2",
         "react": "^18 || ^19"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@tanstack/react-query": "^5.95.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
@@ -779,6 +780,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
+      "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
+      "integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.95.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.2.2",
+    "@tanstack/react-query-devtools": "^5.95.2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@tanstack/react-query": "^5.95.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,12 +1,36 @@
-import { apiClient } from '../../../shared/api/client';
+import { apiClient } from "../../../shared/api/client";
+import type { User } from "../types";
 
 /**
  * CSRFクッキーを取得する
  */
 export const getCsrfCookie = async (): Promise<void> => {
-  await apiClient('/sanctum/csrf-cookie', {
-    method: 'GET',
+  await apiClient("/sanctum/csrf-cookie", {
+    method: "GET",
   });
+};
+
+/**
+ * 現在の認証ユーザーを取得する
+ */
+export const getCurrentUser = async (): Promise<User | null> => {
+  const response = await apiClient("/api/v1/user", {
+    method: "GET",
+  });
+
+  if (response.status === 401) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      (data as { message?: string }).message ??
+        "ユーザー情報の取得に失敗しました",
+    );
+  }
+
+  return response.json() as Promise<User>;
 };
 
 /**
@@ -15,12 +39,14 @@ export const getCsrfCookie = async (): Promise<void> => {
  */
 export const verifyEmail = async (verifyUrl: string): Promise<void> => {
   const response = await apiClient(verifyUrl, {
-    method: 'GET',
+    method: "GET",
   });
 
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
-    throw new Error((data as { message?: string }).message ?? 'メール認証に失敗しました');
+    throw new Error(
+      (data as { message?: string }).message ?? "メール認証に失敗しました",
+    );
   }
 };
 
@@ -28,21 +54,26 @@ export const verifyEmail = async (verifyUrl: string): Promise<void> => {
  * 確認メールを再送する
  * @returns 'sent' | 'already-verified'
  */
-export const resendVerificationEmail = async (): Promise<'sent' | 'already-verified'> => {
-  const response = await apiClient('/api/v1/email/verification-notification', {
-    method: 'POST',
+export const resendVerificationEmail = async (): Promise<
+  "sent" | "already-verified"
+> => {
+  const response = await apiClient("/api/v1/email/verification-notification", {
+    method: "POST",
   });
 
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
-    throw new Error((data as { message?: string }).message ?? '確認メールの再送に失敗しました');
+    throw new Error(
+      (data as { message?: string }).message ??
+        "確認メールの再送に失敗しました",
+    );
   }
 
   const data = await response.json().catch(() => ({}));
-  if ((data as { status?: string }).status === 'already-verified') {
-    return 'already-verified';
+  if ((data as { status?: string }).status === "already-verified") {
+    return "already-verified";
   }
-  return 'sent';
+  return "sent";
 };
 
 /**
@@ -50,14 +81,17 @@ export const resendVerificationEmail = async (): Promise<'sent' | 'already-verif
  */
 export const sendPasswordResetLink = async (email: string): Promise<void> => {
   await getCsrfCookie();
-  const response = await apiClient('/api/v1/forgot-password', {
-    method: 'POST',
+  const response = await apiClient("/api/v1/forgot-password", {
+    method: "POST",
     body: JSON.stringify({ email }),
   });
 
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
-    throw new Error((data as { message?: string }).message ?? 'パスワード再設定メールの送信に失敗しました');
+    throw new Error(
+      (data as { message?: string }).message ??
+        "パスワード再設定メールの送信に失敗しました",
+    );
   }
 };
 
@@ -71,15 +105,20 @@ interface ResetPasswordPayload {
 /**
  * パスワードをリセットする
  */
-export const resetPassword = async (payload: ResetPasswordPayload): Promise<void> => {
+export const resetPassword = async (
+  payload: ResetPasswordPayload,
+): Promise<void> => {
   await getCsrfCookie();
-  const response = await apiClient('/api/v1/reset-password', {
-    method: 'POST',
+  const response = await apiClient("/api/v1/reset-password", {
+    method: "POST",
     body: JSON.stringify(payload),
   });
 
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
-    throw new Error((data as { message?: string }).message ?? 'パスワードのリセットに失敗しました');
+    throw new Error(
+      (data as { message?: string }).message ??
+        "パスワードのリセットに失敗しました",
+    );
   }
 };

--- a/src/features/auth/hooks/useCurrentUser.ts
+++ b/src/features/auth/hooks/useCurrentUser.ts
@@ -1,0 +1,13 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { getCurrentUser } from "../api/auth";
+
+export const authQueryKeys = {
+  currentUser: ["auth", "currentUser"] as const,
+};
+
+export const currentUserQueryOptions = queryOptions({
+  queryKey: authQueryKeys.currentUser,
+  queryFn: getCurrentUser,
+});
+
+export const useCurrentUser = () => useQuery(currentUserQueryOptions);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import "./index.css"; // 全体に適用するスタイルシート
 import { router } from "./routes/config";
-import { AppReactQueryDevtools } from "./shared/api/ReactQueryDevtools.tsx";
+import { AppReactQueryDevtools } from "./shared/api/ReactQueryDevtools";
 import { queryClient } from "./shared/api/queryClient";
 
 // 1. HTML内の id="root" を持つ要素を探し、Reactの「起点」を作成

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,10 @@
 import { StrictMode } from 'react'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import './index.css' // 全体に適用するスタイルシート
 import { router } from './routes/config'
+import { queryClient } from './shared/api/queryClient'
 
 // 1. HTML内の id="root" を持つ要素を探し、Reactの「起点」を作成
 const rootElement = document.getElementById('root')!;
@@ -11,6 +13,8 @@ const root = createRoot(rootElement);
 // 2. Reactアプリを画面に映し出す
 root.render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,13 @@
-import { StrictMode } from 'react'
-import { QueryClientProvider } from '@tanstack/react-query'
-import { createRoot } from 'react-dom/client'
-import { RouterProvider } from 'react-router-dom'
-import './index.css' // 全体に適用するスタイルシート
-import { router } from './routes/config'
-import { queryClient } from './shared/api/queryClient'
+import { StrictMode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { createRoot } from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
+import "./index.css"; // 全体に適用するスタイルシート
+import { router } from "./routes/config";
+import { queryClient } from "./shared/api/queryClient";
 
 // 1. HTML内の id="root" を持つ要素を探し、Reactの「起点」を作成
-const rootElement = document.getElementById('root')!;
+const rootElement = document.getElementById("root")!;
 const root = createRoot(rootElement);
 
 // 2. Reactアプリを画面に映し出す
@@ -16,5 +16,5 @@ root.render(
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
     </QueryClientProvider>
-  </StrictMode>
+  </StrictMode>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import "./index.css"; // 全体に適用するスタイルシート
 import { router } from "./routes/config";
+import { AppReactQueryDevtools } from "./shared/api/ReactQueryDevtools.tsx";
 import { queryClient } from "./shared/api/queryClient";
 
 // 1. HTML内の id="root" を持つ要素を探し、Reactの「起点」を作成
@@ -15,6 +16,7 @@ root.render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <AppReactQueryDevtools />
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/shared/api/ReactQueryDevtools.tsx
+++ b/src/shared/api/ReactQueryDevtools.tsx
@@ -1,0 +1,12 @@
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+const isReactQueryDevtoolsEnabled =
+  import.meta.env.DEV && import.meta.env.VITE_DEBUG === 'true';
+
+export function AppReactQueryDevtools() {
+  if (!isReactQueryDevtoolsEnabled) {
+    return null;
+  }
+
+  return <ReactQueryDevtools initialIsOpen={false} />;
+}

--- a/src/shared/api/queryClient.ts
+++ b/src/shared/api/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient } from "@tanstack/react-query";
 
 const ONE_MINUTE = 60 * 1000;
 
@@ -14,7 +14,7 @@ export const queryClient = new QueryClient({
 });
 
 // 認証状態はフォーカス復帰ごとに再取得せず、明示的な無効化や再訪時に更新する。
-queryClient.setQueryDefaults(['auth'], {
+queryClient.setQueryDefaults(["auth"], {
   retry: false,
   refetchOnWindowFocus: false,
   refetchOnMount: false,

--- a/src/shared/api/queryClient.ts
+++ b/src/shared/api/queryClient.ts
@@ -1,0 +1,21 @@
+import { QueryClient } from '@tanstack/react-query';
+
+const ONE_MINUTE = 60 * 1000;
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: ONE_MINUTE,
+      gcTime: 5 * ONE_MINUTE,
+      refetchOnReconnect: true,
+    },
+  },
+});
+
+// 認証状態はフォーカス復帰ごとに再取得せず、明示的な無効化や再訪時に更新する。
+queryClient.setQueryDefaults(['auth'], {
+  retry: false,
+  refetchOnWindowFocus: false,
+  refetchOnMount: false,
+});


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

**概要**
TanStack Query を導入し、サーバー状態管理の基盤を整備した。認証済みユーザーの取得処理を `useCurrentUser` フックとして実装し、開発時のデバッグ効率向上のため `VITE_DEBUG` フラグで制御可能な Devtools を組み込んだ。

| # | 対象 | 変更内容 |
|---|------|----------|
| 1 | `package.json` | `@tanstack/react-query` / `@tanstack/react-query-devtools` を依存に追加 |
| 2 | `src/shared/api/queryClient.ts` | `QueryClient` を作成し、リトライ・キャッシュ・再取得方針を初期値として定義 |
| 3 | `src/main.tsx` | `QueryClientProvider` でアプリ全体をラップし、全画面で Query を利用可能に |
| 4 | `src/features/auth/api/auth.ts` | `getCurrentUser` 関数を追加し、未認証・エラー状態を適切にハンドリング |
| 5 | `src/features/auth/hooks/useCurrentUser.ts` | `useCurrentUser` フックとクエリオプションを新規作成 |
| 6 | `src/shared/api/ReactQueryDevtools.tsx` | `VITE_DEBUG` フラグによる Devtools の条件付き表示コンポーネントを追加 |
| 7 | `.env.example` | `VITE_DEBUG` を React Query Devtools の表示制御にも利用することを追記 |

**変更の目的**
- 認証状態の取得をサーバー状態として管理し、キャッシュ・再取得の制御を一元化する
- 認証系クエリはフォーカス時・マウント時の再取得を抑制し、不要なAPIリクエストを防ぐ
- Devtools を環境変数で制御することで、本番環境への混入リスクなくデバッグ手段を提供する