### PR TITLE
feat:[13.3] ログインフォームを React Hook Form + Zod で実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,17 @@
       "version": "0.0.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.95.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-hook-form": "^7.72.1",
         "react-router-dom": "^7.13.1",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -589,6 +592,18 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
       "dev": true,
@@ -701,6 +716,12 @@
       "os": [
         "linux"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
@@ -849,15 +870,6 @@
         "@types/babel__template": "*",
         "@types/babel__traverse": "*"
       }
-    },
-    "node_modules/@types/babel__generator": {
-      "dev": true
-    },
-    "node_modules/@types/babel__template": {
-      "dev": true
-    },
-    "node_modules/@types/babel__traverse": {
-      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2414,6 +2426,22 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.72.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
+      "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "dev": true,
@@ -2791,8 +2819,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "dev": true,
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -11,14 +11,17 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.95.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-hook-form": "^7.72.1",
     "react-router-dom": "^7.13.1",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,5 +1,8 @@
-import { useState, type FormEvent } from 'react';
+import { useState } from 'react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useLogin } from '../hooks/useLogin';
+import { loginSchema, type LoginFormValues } from '../schemas/loginSchema';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -16,13 +19,20 @@ interface LoginFormProps {
 }
 
 export const LoginForm = ({ onLoginSuccess }: LoginFormProps) => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const { mutate: login, isPending, error } = useLogin();
+  const [serverError, setServerError] = useState<string | null>(null);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({ resolver: zodResolver(loginSchema) });
+  const { mutate: login, isPending } = useLogin();
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    login({ email, password }, { onSuccess: onLoginSuccess });
+  const onSubmit: SubmitHandler<LoginFormValues> = (data) => {
+    setServerError(null);
+    login(data, {
+      onSuccess: onLoginSuccess,
+      onError: (error) => setServerError(error.message),
+    });
   };
 
   return (
@@ -33,28 +43,32 @@ export const LoginForm = ({ onLoginSuccess }: LoginFormProps) => {
       </CardHeader>
       <Separator />
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-1.5">
             <label htmlFor="login-email" className="block text-sm font-medium">メールアドレス</label>
             <Input
               id="login-email"
               type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
+              disabled={isPending}
+              {...register('email')}
             />
+            {errors.email && (
+              <p className="text-sm text-destructive">{errors.email.message}</p>
+            )}
           </div>
           <div className="space-y-1.5">
             <label htmlFor="login-password" className="block text-sm font-medium">パスワード</label>
             <Input
               id="login-password"
               type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
+              disabled={isPending}
+              {...register('password')}
             />
+            {errors.password && (
+              <p className="text-sm text-destructive">{errors.password.message}</p>
+            )}
           </div>
-          {error && <p className="text-sm text-destructive">{error.message}</p>}
+          {serverError && <p className="text-sm text-destructive">{serverError}</p>}
           <Button
             type="submit"
             disabled={isPending}

--- a/src/features/auth/schemas/loginSchema.ts
+++ b/src/features/auth/schemas/loginSchema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'メールアドレスを入力してください')
+    .email('メールアドレスの形式が正しくありません'),
+  password: z.string().min(1, 'パスワードを入力してください'),
+});
+
+export type LoginFormValues = z.infer<typeof loginSchema>;

--- a/src/features/auth/schemas/loginSchema.ts
+++ b/src/features/auth/schemas/loginSchema.ts
@@ -2,9 +2,8 @@ import { z } from 'zod';
 
 export const loginSchema = z.object({
   email: z
-    .string()
-    .min(1, 'メールアドレスを入力してください')
-    .email('メールアドレスの形式が正しくありません'),
+  .email('メールアドレスの形式が正しくありません')
+  .min(1, 'メールアドレスを入力してください'),
   password: z.string().min(1, 'パスワードを入力してください'),
 });
 


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

**概要**
`LoginForm` のフォーム管理を手動 state から `react-hook-form` に移行し、Zod スキーマによるバリデーションを導入した。バリデーションエラーをインライン表示できるようになり、フォームの状態管理と入力検証の責務を分離している。

| # | 対象 | 変更内容 |
|---|------|----------|
| 1 | `package.json` | `react-hook-form` / `@hookform/resolvers` / `zod` を依存に追加 |
| 2 | `src/features/auth/schemas/loginSchema.ts` | Zod による `loginSchema` と `LoginFormValues` 型を新規定義（エラーメッセージは日本語） |
| 3 | `src/features/auth/components/LoginForm.tsx` | 手動 state 管理を廃止し `react-hook-form` によるフォーム制御に移行、バリデーションエラーをインライン表示 |

**変更の目的**
- 手動 state によるフォーム管理はバリデーション追加時に肥大化しやすいため、専用ライブラリに委譲する
- Zod スキーマでバリデーションルールを宣言的に定義し、型定義とバリデーションを一元管理する
- エラーメッセージを日本語で統一し、ユーザーへのフィードバックを適切な言語で提供する

**動作確認**
- [x] メールアドレス・パスワードが未入力の場合にバリデーションエラーが表示されること
- [x] 不正なメールアドレス形式でバリデーションエラーが表示されること
- [x] 正しい認証情報でログインが成功しリダイレクトされること
- [x] 誤った認証情報でサーバーエラーメッセージが表示されること