### PR TITLE
ci: 親リポジトリへのサブモジュール更新通知ワークフローを追加

### DIFF
--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -1,0 +1,17 @@
+name: Notify Parent Repository
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger parent update
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PAT_SHIFTY }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/takuya-ya/shifty/dispatches \
+            -d '{"event_type":"submodule-updated"}'

--- a/.github/workflows/notify-parent.yml
+++ b/.github/workflows/notify-parent.yml
@@ -14,4 +14,4 @@ jobs:
             -H "Authorization: token ${{ secrets.PAT_SHIFTY }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/takuya-ya/shifty/dispatches \
-            -d '{"event_type":"submodule-updated"}'
+            -d '{"event_type":"submodule-updated","client_payload":{"submodule":"frontend"}}'


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

**概要**
mainブランチへのpush時に、親リポジトリ（shifty）へ`repository_dispatch`イベントを送信するGitHub Actionsワークフローを追加した。

| # | 対象 | 変更内容 |
|---|------|----------|
| 1 | `.github/workflows/notify-parent.yml` | 親リポジトリへの通知ワークフローを新規追加 |

**変更の目的**
- サブモジュールのmainへのマージを契機に、親リポジトリのサブモジュールポインタを自動更新する仕組みを整備する
- 手動でのサブモジュールポインタ更新コミット作業を不要にする

**動作確認**
- [x] `PAT_SHIFTY` シークレットがリポジトリの Settings > Secrets に登録されていることを確認（事前条件）
- [x] このPRをmainにマージ後、shiftyリポジトリの Actions タブで `Update Submodule Pointer` ワークフローが起動することを確認