### PR TITLE
feat: [13.5] パスワード再設定フォームのreact-hook-form + Zod統一対応

### DIFF
--- a/src/features/auth/components/ForgotPasswordForm.tsx
+++ b/src/features/auth/components/ForgotPasswordForm.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@/components/ui/button';
@@ -25,12 +26,13 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
   const {
     register,
     handleSubmit,
-    getValues,
     formState: { errors },
   } = useForm<ForgotPasswordFormValues>({ resolver: zodResolver(forgotPasswordSchema) });
   const { mutate: sendResetLink, isPending, isSuccess, error } = useForgotPassword();
+  const submittedEmail = useRef<string>('');
 
   const onSubmit: SubmitHandler<ForgotPasswordFormValues> = (data) => {
+    submittedEmail.current = data.email;
     sendResetLink(data.email);
   };
 
@@ -40,7 +42,7 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
         <CardHeader>
           <CardTitle>メールを送信しました</CardTitle>
           <CardDescription>
-            パスワード再設定のリンクを <strong>{getValues('email')}</strong> に送信しました。メールをご確認ください。
+            パスワード再設定のリンクを <strong>{submittedEmail.current}</strong> に送信しました。メールをご確認ください。
           </CardDescription>
         </CardHeader>
         <CardFooter className="justify-center">

--- a/src/features/auth/components/ForgotPasswordForm.tsx
+++ b/src/features/auth/components/ForgotPasswordForm.tsx
@@ -1,4 +1,5 @@
-import { useState, type FormEvent } from 'react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -11,18 +12,26 @@ import {
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { useForgotPassword } from '../hooks/useForgotPassword';
+import {
+  forgotPasswordSchema,
+  type ForgotPasswordFormValues,
+} from '../schemas/forgotPasswordSchema';
 
 interface ForgotPasswordFormProps {
   onSwitchToLogin: () => void;
 }
 
 export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps) {
-  const [email, setEmail] = useState('');
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    formState: { errors },
+  } = useForm<ForgotPasswordFormValues>({ resolver: zodResolver(forgotPasswordSchema) });
   const { mutate: sendResetLink, isPending, isSuccess, error } = useForgotPassword();
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    sendResetLink(email);
+  const onSubmit: SubmitHandler<ForgotPasswordFormValues> = (data) => {
+    sendResetLink(data.email);
   };
 
   if (isSuccess) {
@@ -31,7 +40,7 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
         <CardHeader>
           <CardTitle>メールを送信しました</CardTitle>
           <CardDescription>
-            パスワード再設定のリンクを <strong>{email}</strong> に送信しました。メールをご確認ください。
+            パスワード再設定のリンクを <strong>{getValues('email')}</strong> に送信しました。メールをご確認ください。
           </CardDescription>
         </CardHeader>
         <CardFooter className="justify-center">
@@ -53,19 +62,21 @@ export function ForgotPasswordForm({ onSwitchToLogin }: ForgotPasswordFormProps)
       </CardHeader>
       <Separator />
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-1.5">
-            <label htmlFor="email" className="block text-sm font-medium">
+            <label htmlFor="forgot-password-email" className="block text-sm font-medium">
               メールアドレス
             </label>
             <Input
-              id="email"
+              id="forgot-password-email"
               type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
+              disabled={isPending}
               autoComplete="email"
+              {...register('email')}
             />
+            {errors.email && (
+              <p className="text-sm text-destructive">{errors.email.message}</p>
+            )}
           </div>
           {error && (
             <p className="text-sm text-destructive">{error.message}</p>

--- a/src/features/auth/components/ResetPasswordForm.tsx
+++ b/src/features/auth/components/ResetPasswordForm.tsx
@@ -1,4 +1,5 @@
-import { useState, type FormEvent } from 'react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -10,6 +11,10 @@ import {
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { useResetPassword } from '../hooks/useResetPassword';
+import {
+  resetPasswordSchema,
+  type ResetPasswordFormValues,
+} from '../schemas/resetPasswordSchema';
 
 interface ResetPasswordFormProps {
   token: string;
@@ -18,14 +23,16 @@ interface ResetPasswordFormProps {
 }
 
 export function ResetPasswordForm({ token, email, onSuccess }: ResetPasswordFormProps) {
-  const [password, setPassword] = useState('');
-  const [passwordConfirmation, setPasswordConfirmation] = useState('');
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ResetPasswordFormValues>({ resolver: zodResolver(resetPasswordSchema) });
   const { mutate: resetPassword, isPending, error } = useResetPassword();
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
+  const onSubmit: SubmitHandler<ResetPasswordFormValues> = (data) => {
     resetPassword(
-      { token, email, password, password_confirmation: passwordConfirmation },
+      { token, email, password: data.password, password_confirmation: data.password_confirmation },
       { onSuccess },
     );
   };
@@ -40,32 +47,36 @@ export function ResetPasswordForm({ token, email, onSuccess }: ResetPasswordForm
       </CardHeader>
       <Separator />
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-1.5">
-            <label htmlFor="password" className="block text-sm font-medium">
+            <label htmlFor="reset-password" className="block text-sm font-medium">
               新しいパスワード
             </label>
             <Input
-              id="password"
+              id="reset-password"
               type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
+              disabled={isPending}
               autoComplete="new-password"
+              {...register('password')}
             />
+            {errors.password && (
+              <p className="text-sm text-destructive">{errors.password.message}</p>
+            )}
           </div>
           <div className="space-y-1.5">
-            <label htmlFor="password_confirmation" className="block text-sm font-medium">
+            <label htmlFor="reset-password-confirmation" className="block text-sm font-medium">
               パスワード（確認）
             </label>
             <Input
-              id="password_confirmation"
+              id="reset-password-confirmation"
               type="password"
-              value={passwordConfirmation}
-              onChange={(e) => setPasswordConfirmation(e.target.value)}
-              required
+              disabled={isPending}
               autoComplete="new-password"
+              {...register('password_confirmation')}
             />
+            {errors.password_confirmation && (
+              <p className="text-sm text-destructive">{errors.password_confirmation.message}</p>
+            )}
           </div>
           {error && (
             <p className="text-sm text-destructive">{error.message}</p>

--- a/src/features/auth/schemas/forgotPasswordSchema.ts
+++ b/src/features/auth/schemas/forgotPasswordSchema.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 
-export const loginSchema = z.object({
+export const forgotPasswordSchema = z.object({
   email: z
     .string()
     .min(1, "メールアドレスを入力してください")
     .pipe(z.email("メールアドレスの形式が正しくありません")),
-  password: z.string().min(1, "パスワードを入力してください"),
 });
 
-export type LoginFormValues = z.infer<typeof loginSchema>;
+export type ForgotPasswordFormValues = z.infer<typeof forgotPasswordSchema>;

--- a/src/features/auth/schemas/registerSchema.ts
+++ b/src/features/auth/schemas/registerSchema.ts
@@ -1,21 +1,24 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 export const registerSchema = z
   .object({
-    name: z.string().min(1, '名前を入力してください').max(255, '名前は255文字以内で入力してください'),
+    name: z
+      .string()
+      .min(1, "名前を入力してください")
+      .max(255, "名前は255文字以内で入力してください"),
     email: z
       .string()
-      .min(1, 'メールアドレスを入力してください')
-      .max(255, 'メールアドレスは255文字以内で入力してください')
-      .pipe(z.email('メールアドレスの形式が正しくありません')),
-    password: z
+      .min(1, "メールアドレスを入力してください")
+      .max(255, "メールアドレスは255文字以内で入力してください")
+      .pipe(z.email("メールアドレスの形式が正しくありません")),
+    password: z.string().min(8, "パスワードは8文字以上で入力してください"),
+    password_confirmation: z
       .string()
-      .min(8, 'パスワードは8文字以上で入力してください'),
-    password_confirmation: z.string().min(1, 'パスワード(確認)を入力してください'),
+      .min(1, "パスワード(確認)を入力してください"),
   })
   .refine((data) => data.password === data.password_confirmation, {
-    message: 'パスワードが一致しません',
-    path: ['password_confirmation'],
+    message: "パスワードが一致しません",
+    path: ["password_confirmation"],
   });
 
 export type RegisterFormValues = z.infer<typeof registerSchema>;

--- a/src/features/auth/schemas/resetPasswordSchema.ts
+++ b/src/features/auth/schemas/resetPasswordSchema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(8, "パスワードは8文字以上で入力してください"),
+    password_confirmation: z
+      .string()
+      .min(1, "パスワード(確認)を入力してください"),
+  })
+  .refine((data) => data.password === data.password_confirmation, {
+    message: "パスワードが一致しません",
+    path: ["password_confirmation"],
+  });
+
+export type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,6 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

## 概要

`ForgotPasswordForm` と `ResetPasswordForm` を、`LoginForm` / `RegisterForm` と同じ `react-hook-form + Zod` のパターンに統一した。

## 対象 変更内容

1. `forgotPasswordSchema.ts` を新規作成し、email バリデーションを定義
2. `ForgotPasswordForm.tsx` を `useForm + zodResolver` に移行（disabled制御・htmlFor修正含む）
3. `resetPasswordSchema.ts` を新規作成し、パスワード一致チェックを含むバリデーションを定義
4. `ResetPasswordForm.tsx` を `useForm + zodResolver` に移行（disabled制御・htmlFor修正・パスワード一致チェック含む）

## 変更の目的

- 全認証フォームで実装パターンを統一するため
- クライアント側でのバリデーション（空入力チェック・パスワード一致チェック）を追加するため
- 送信中の `disabled` 制御を追加してUXを改善するため

## 動作確認

- [x] パスワード再設定リンク送信フォームで空入力時にエラーメッセージが表示される
- [x] パスワード再設定リンク送信フォームで不正なメール形式時にエラーメッセージが表示される
- [x] パスワード再設定フォームでパスワード不一致時にエラーメッセージが表示される
- [x] 各フォームで送信中に入力とボタンが無効化される