### PR TITLE
feat: [13.7] 認証状態管理・RouteGuard 実装

### DIFF
--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -6,11 +6,12 @@ import { useCurrentUser } from "./useCurrentUser";
  * useCurrentUser の詳細を知らずに認証状態を参照できるようにする。
  */
 export const useAuth = () => {
-  const { data: user, isLoading } = useCurrentUser();
+  const { data: user, isLoading, isError } = useCurrentUser();
 
   return {
     user: user ?? null,
     isAuthenticated: !!user,
     isLoading,
+    isError,
   };
 };

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,8 +1,12 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { LoginForm } from '../features/auth/components/LoginForm';
 import { PATHS } from '../routes/paths';
 
 export function LoginPage() {
   const navigate = useNavigate();
-  return <LoginForm onLoginSuccess={() => navigate(PATHS.ADMIN_SHIFTS)} />;
+  const location = useLocation();
+  const from = (location.state as { from?: { pathname: string; search: string } } | null)?.from;
+  const redirectTo = from ? `${from.pathname}${from.search}` : PATHS.ADMIN_SHIFTS;
+
+  return <LoginForm onLoginSuccess={() => navigate(redirectTo, { replace: true })} />;
 }

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,27 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from '../features/auth/hooks/useAuth'
+import { PATHS } from './paths'
+
+// ──────────────────────────────────────────────────────────────
+// ProtectedRoute: 認証済みユーザーのみアクセス可
+// - useAuth で認証状態を判定する（固定値 prop 不要）
+// - isLoading 中は誤リダイレクトを防ぐためローディングUIを返す
+// - 未認証の場合は /login にリダイレクトする
+// ──────────────────────────────────────────────────────────────
+export function ProtectedRoute() {
+  const { isAuthenticated, isLoading } = useAuth()
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-sm text-gray-500">
+        認証情報を確認中...
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to={PATHS.LOGIN} replace />
+  }
+
+  return <Outlet />
+}

--- a/src/routes/RouteGuard.tsx
+++ b/src/routes/RouteGuard.tsx
@@ -37,7 +37,9 @@ export function RouteGuard({ requireAuth }: Props) {
   }
 
   if (!requireAuth && isAuthenticated) {
-    return <Navigate to={PATHS.ADMIN_SHIFTS} replace />
+    const from = (location.state as { from?: { pathname: string; search: string } } | null)?.from
+    const redirectTo = from ? `${from.pathname}${from.search}` : PATHS.ADMIN_SHIFTS
+    return <Navigate to={redirectTo} replace />
   }
 
   return <Outlet />

--- a/src/routes/RouteGuard.tsx
+++ b/src/routes/RouteGuard.tsx
@@ -2,13 +2,17 @@ import { Navigate, Outlet } from 'react-router-dom'
 import { useAuth } from '../features/auth/hooks/useAuth'
 import { PATHS } from './paths'
 
+type Props = {
+  requireAuth: boolean
+}
+
 // ──────────────────────────────────────────────────────────────
-// ProtectedRoute: 認証済みユーザーのみアクセス可
-// - useAuth で認証状態を判定する（固定値 prop 不要）
+// RouteGuard: 認証状態に応じてルートへのアクセスを制御する
+// - requireAuth=true : 未認証ユーザーを /login にリダイレクト
+// - requireAuth=false: 認証済みユーザーを /admin/shifts にリダイレクト
 // - isLoading 中は誤リダイレクトを防ぐためローディングUIを返す
-// - 未認証の場合は /login にリダイレクトする
 // ──────────────────────────────────────────────────────────────
-export function ProtectedRoute() {
+export function RouteGuard({ requireAuth }: Props) {
   const { isAuthenticated, isLoading } = useAuth()
 
   if (isLoading) {
@@ -19,8 +23,12 @@ export function ProtectedRoute() {
     )
   }
 
-  if (!isAuthenticated) {
+  if (requireAuth && !isAuthenticated) {
     return <Navigate to={PATHS.LOGIN} replace />
+  }
+
+  if (!requireAuth && isAuthenticated) {
+    return <Navigate to={PATHS.ADMIN_SHIFTS} replace />
   }
 
   return <Outlet />

--- a/src/routes/RouteGuard.tsx
+++ b/src/routes/RouteGuard.tsx
@@ -24,15 +24,7 @@ export function RouteGuard({ requireAuth }: Props) {
     )
   }
 
-  if (isError) {
-    return (
-      <div className="flex items-center justify-center py-16 text-sm text-red-500">
-        認証情報の取得に失敗しました。ネットワーク接続を確認してください。
-      </div>
-    )
-  }
-
-  if (requireAuth && !isAuthenticated) {
+  if (requireAuth && !isAuthenticated && !isError) {
     return <Navigate to={PATHS.LOGIN} state={{ from: location }} replace />
   }
 
@@ -42,5 +34,14 @@ export function RouteGuard({ requireAuth }: Props) {
     return <Navigate to={redirectTo} replace />
   }
 
-  return <Outlet />
+  return (
+    <>
+      <Outlet />
+      {isError && (
+        <div className="flex items-center justify-center py-4 text-sm text-red-500">
+          認証情報の取得に失敗しました。ネットワーク接続を確認してください。
+        </div>
+      )}
+    </>
+  )
 }

--- a/src/routes/RouteGuard.tsx
+++ b/src/routes/RouteGuard.tsx
@@ -13,12 +13,20 @@ type Props = {
 // - isLoading 中は誤リダイレクトを防ぐためローディングUIを返す
 // ──────────────────────────────────────────────────────────────
 export function RouteGuard({ requireAuth }: Props) {
-  const { isAuthenticated, isLoading } = useAuth()
+  const { isAuthenticated, isLoading, isError } = useAuth()
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-16 text-sm text-gray-500">
         認証情報を確認中...
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center py-16 text-sm text-red-500">
+        認証情報の取得に失敗しました。ネットワーク接続を確認してください。
       </div>
     )
   }

--- a/src/routes/RouteGuard.tsx
+++ b/src/routes/RouteGuard.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet } from 'react-router-dom'
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useAuth } from '../features/auth/hooks/useAuth'
 import { PATHS } from './paths'
 
@@ -14,6 +14,7 @@ type Props = {
 // ──────────────────────────────────────────────────────────────
 export function RouteGuard({ requireAuth }: Props) {
   const { isAuthenticated, isLoading, isError } = useAuth()
+  const location = useLocation()
 
   if (isLoading) {
     return (
@@ -32,7 +33,7 @@ export function RouteGuard({ requireAuth }: Props) {
   }
 
   if (requireAuth && !isAuthenticated) {
-    return <Navigate to={PATHS.LOGIN} replace />
+    return <Navigate to={PATHS.LOGIN} state={{ from: location }} replace />
   }
 
   if (!requireAuth && isAuthenticated) {

--- a/src/routes/config.tsx
+++ b/src/routes/config.tsx
@@ -56,7 +56,7 @@ export const router = createBrowserRouter([
           },
         ],
       },
-      // パスワード再設定はトークン付きアクセスのため認証状態によらずアクセス可
+      // パスワード再設定関連のルートは認証状態によらずアクセス可
       {
         path: PATHS.RESET_PASSWORD,
         element: <ResetPasswordPage />,

--- a/src/routes/config.tsx
+++ b/src/routes/config.tsx
@@ -7,7 +7,7 @@ import { NotFoundPage } from '../pages/NotFoundPage'
 import { ResetPasswordPage } from '../pages/ResetPasswordPage'
 import { SettingsPage } from '../pages/SettingsPage'
 import { AppLayout } from '../shared/components/layout/AppLayout'
-import { ProtectedRoute } from './ProtectedRoute'
+import { RouteGuard } from './RouteGuard'
 import { PATHS } from './paths'
 
 // ──────────────────────────────────────────────────────────────
@@ -23,85 +23,85 @@ const links = [
   { to: PATHS.SETTINGS, label: '設定' },
 ]
 
-/** 認証不要のルート */
-const publicRoutes = [
-  {
-    index: true,
-    element: <Navigate to={PATHS.LOGIN} replace />,
-  },
-  {
-    path: PATHS.LOGIN,
-    element: <LoginPage />,
-    handle: {
-      title: 'ログイン',
-      description: '認証前ユーザー向けのログイン画面です。',
-    },
-  },
-  {
-    path: PATHS.RESET_PASSWORD,
-    element: <ResetPasswordPage />,
-    handle: {
-      title: 'パスワード再設定',
-      description: 'ログイン前に、再設定リンク送信用のメールアドレスを入力する画面です。',
-    },
-  },
-  {
-    path: PATHS.PASSWORD_RESET_WITH_TOKEN,
-    element: <ResetPasswordPage />,
-    handle: {
-      title: 'パスワード再設定',
-      description: 'ログインできない人向けの復旧用パスワード再設定画面です。',
-    },
-  },
-  {
-    path: PATHS.ADMIN_REGISTER,
-    element: <AdminRegisterPage />,
-    handle: {
-      title: '管理者登録',
-      description: '認証前ユーザー向けの管理者登録画面です。',
-    },
-  },
-]
-
-/** 認証必須のルート */
-const privateRoutes = [
-  {
-    path: PATHS.ADMIN_SHIFTS,
-    element: <AdminShiftsPage />,
-    handle: {
-      title: '管理者シフト管理',
-      description: '認証後ユーザー向けのメイン画面です。',
-    },
-  },
-  {
-    path: PATHS.ADMIN_STAFFS,
-    element: <AdminStaffsPage />,
-    handle: {
-      title: 'スタッフ管理',
-      description: '認証後ユーザー向けのスタッフ管理画面です。',
-    },
-  },
-  {
-    path: PATHS.SETTINGS,
-    element: <SettingsPage />,
-    handle: {
-      title: '設定',
-      description: '認証後ユーザー向けの設定画面です。',
-    },
-  },
-]
-
 export const router = createBrowserRouter([
   {
     path: PATHS.ROOT,
     element: <AppLayout appName="Shifty" navigation={links} />,
     children: [
-      ...publicRoutes,
-      // ProtectedRoute をネスト layout として認証必須ルートを一括保護する。
-      // 未認証アクセスはすべて /login へリダイレクトされる。
+      // ルートアクセスは /login へリダイレクト
       {
-        element: <ProtectedRoute />,
-        children: privateRoutes,
+        index: true,
+        element: <Navigate to={PATHS.LOGIN} replace />,
+      },
+      // requireAuth=false: 認証済みユーザーを /admin/shifts にリダイレクト
+      // ログイン・管理者登録は未認証ユーザー専用
+      {
+        element: <RouteGuard requireAuth={false} />,
+        children: [
+          {
+            path: PATHS.LOGIN,
+            element: <LoginPage />,
+            handle: {
+              title: 'ログイン',
+              description: '認証前ユーザー向けのログイン画面です。',
+            },
+          },
+          {
+            path: PATHS.ADMIN_REGISTER,
+            element: <AdminRegisterPage />,
+            handle: {
+              title: '管理者登録',
+              description: '認証前ユーザー向けの管理者登録画面です。',
+            },
+          },
+        ],
+      },
+      // パスワード再設定はトークン付きアクセスのため認証状態によらずアクセス可
+      {
+        path: PATHS.RESET_PASSWORD,
+        element: <ResetPasswordPage />,
+        handle: {
+          title: 'パスワード再設定',
+          description: 'ログイン前に、再設定リンク送信用のメールアドレスを入力する画面です。',
+        },
+      },
+      {
+        path: PATHS.PASSWORD_RESET_WITH_TOKEN,
+        element: <ResetPasswordPage />,
+        handle: {
+          title: 'パスワード再設定',
+          description: 'ログインできない人向けの復旧用パスワード再設定画面です。',
+        },
+      },
+      // requireAuth=true: 未認証ユーザーを /login にリダイレクト
+      {
+        element: <RouteGuard requireAuth={true} />,
+        children: [
+          {
+            path: PATHS.ADMIN_SHIFTS,
+            element: <AdminShiftsPage />,
+            handle: {
+              title: '管理者シフト管理',
+              description: '認証後ユーザー向けのメイン画面です。',
+            },
+          },
+          {
+            path: PATHS.ADMIN_STAFFS,
+            element: <AdminStaffsPage />,
+            handle: {
+              title: 'スタッフ管理',
+              description: '認証後ユーザー向けのスタッフ管理画面です。',
+            },
+          },
+          {
+            path: PATHS.SETTINGS,
+            element: <SettingsPage />,
+            handle: {
+              title: '設定',
+              description: '認証後ユーザー向けの設定画面です。',
+            },
+          },
+        ],
       },
     ],
   },

--- a/src/routes/config.tsx
+++ b/src/routes/config.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react'
 import { createBrowserRouter, Navigate } from 'react-router-dom'
 import { AdminRegisterPage } from '../pages/AdminRegisterPage'
 import { AdminShiftsPage } from '../pages/AdminShiftsPage'
@@ -8,24 +7,8 @@ import { NotFoundPage } from '../pages/NotFoundPage'
 import { ResetPasswordPage } from '../pages/ResetPasswordPage'
 import { SettingsPage } from '../pages/SettingsPage'
 import { AppLayout } from '../shared/components/layout/AppLayout'
+import { ProtectedRoute } from './ProtectedRoute'
 import { PATHS } from './paths'
-
-// ──────────────────────────────────────────────────────────────
-// ProtectedRoute: 認証済みユーザーのみアクセス可
-// 未認証の場合は /login にリダイレクトする。
-// 認証状態の判定は 12.2.3 以降で useAuth を使って差し替える。
-// ──────────────────────────────────────────────────────────────
-interface ProtectedRouteProps {
-  children: ReactNode
-  isAuthenticated: boolean
-}
-
-export function ProtectedRoute({ children, isAuthenticated }: ProtectedRouteProps) {
-  if (!isAuthenticated) {
-    return <Navigate to={PATHS.LOGIN} replace />
-  }
-  return <>{children}</>
-}
 
 // ──────────────────────────────────────────────────────────────
 // ルート定義
@@ -80,13 +63,8 @@ const publicRoutes = [
   },
 ]
 
-/**
- * 認証必須のルート（将来的にProtectedRouteでラップ予定）
- *
- * 現状はまだProtectedRouteでラップされていません。
- * // 13.7 認証状態管理・PrivateRoute 実装後に、ProtectedRoute でラップするためのルート定義。
- */
-const protectedRoutes = [
+/** 認証必須のルート */
+const privateRoutes = [
   {
     path: PATHS.ADMIN_SHIFTS,
     element: <AdminShiftsPage />,
@@ -117,7 +95,15 @@ export const router = createBrowserRouter([
   {
     path: PATHS.ROOT,
     element: <AppLayout appName="Shifty" navigation={links} />,
-    children: [...publicRoutes, ...protectedRoutes],
+    children: [
+      ...publicRoutes,
+      // ProtectedRoute をネスト layout として認証必須ルートを一括保護する。
+      // 未認証アクセスはすべて /login へリダイレクトされる。
+      {
+        element: <ProtectedRoute />,
+        children: privateRoutes,
+      },
+    ],
   },
   {
     path: PATHS.NOT_FOUND,


### PR DESCRIPTION
## 概要

- `RouteGuard` コンポーネントを新規作成し、認証必須ルートと未認証専用ルートを一元管理
- `useAuth` ベースの認証判定に差し替え（固定値 prop 依存を解消）
- 認証判定中のローディングUIを実装し、初回表示の誤リダイレクトを防止
- 認証済みユーザーの `/login`・`/admin/register` アクセス時に `/admin/shifts` へリダイレクト

## 変更ファイル

- `frontend/src/routes/RouteGuard.tsx`（新規）：`requireAuth` prop で双方向のルート保護を担う単一コンポーネント
- `frontend/src/routes/config.tsx`：保護ルートを `RouteGuard` のネスト layout でラップ

## 動作確認

- [x] 未認証状態で `/admin/shifts` にアクセス → `/login` にリダイレクトされること
- [x] ログイン後に `/login` にアクセス → `/admin/shifts` にリダイレクトされること
- [x] ページ初回ロード時（認証チェック中）にローディングUIが表示されること
- [x] ログアウト後に保護ルートへアクセス → `/login` にリダイレクトされること