### PR TITLE
feat: [14] fetch API クライアント共通化・エラーハンドリング整備

### DIFF
--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -22,7 +22,8 @@ export interface ResetPasswordPayload {
 }
 
 export const getCsrfCookie = async (): Promise<void> => {
-  await get("/sanctum/csrf-cookie");
+  const response = await get("/sanctum/csrf-cookie");
+  await throwIfNotOk(response, "CSRFトークンの取得に失敗しました");
 };
 
 export const login = async (payload: LoginPayload): Promise<void> => {

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiClient } from "../../../shared/api/client";
+import { get, post } from "../../../shared/api/client";
 import { throwIfNotOk } from "../../../shared/api/error";
 import type { User } from "../types";
 
@@ -22,48 +22,40 @@ export interface ResetPasswordPayload {
 }
 
 export const getCsrfCookie = async (): Promise<void> => {
-  await apiClient("/sanctum/csrf-cookie", { method: "GET" });
+  await get("/sanctum/csrf-cookie");
 };
 
 export const login = async (payload: LoginPayload): Promise<void> => {
   await getCsrfCookie();
-  const response = await apiClient("/api/v1/login", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+  const response = await post("/api/v1/login", payload);
   await throwIfNotOk(response, "ログインに失敗しました");
 };
 
 export const register = async (payload: RegisterPayload): Promise<void> => {
   await getCsrfCookie();
-  const response = await apiClient("/api/v1/register", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+  const response = await post("/api/v1/register", payload);
   await throwIfNotOk(response, "登録に失敗しました");
 };
 
 export const logout = async (): Promise<void> => {
-  const response = await apiClient("/api/v1/logout", { method: "POST" });
+  const response = await post("/api/v1/logout");
   await throwIfNotOk(response, "ログアウトに失敗しました");
 };
 
 export const getCurrentUser = async (): Promise<User | null> => {
-  const response = await apiClient("/api/v1/user", { method: "GET" });
+  const response = await get("/api/v1/user");
   if (response.status === 401) return null;
   await throwIfNotOk(response, "ユーザー情報の取得に失敗しました");
   return response.json() as Promise<User>;
 };
 
 export const verifyEmail = async (verifyUrl: string): Promise<void> => {
-  const response = await apiClient(verifyUrl, { method: "GET" });
+  const response = await get(verifyUrl);
   await throwIfNotOk(response, "メール認証に失敗しました");
 };
 
 export const resendVerificationEmail = async (): Promise<"sent" | "already-verified"> => {
-  const response = await apiClient("/api/v1/email/verification-notification", {
-    method: "POST",
-  });
+  const response = await post("/api/v1/email/verification-notification");
   await throwIfNotOk(response, "確認メールの再送に失敗しました");
   const data = await response.json().catch(() => ({}));
   return (data as { status?: string }).status === "already-verified"
@@ -73,18 +65,12 @@ export const resendVerificationEmail = async (): Promise<"sent" | "already-verif
 
 export const sendPasswordResetLink = async (email: string): Promise<void> => {
   await getCsrfCookie();
-  const response = await apiClient("/api/v1/forgot-password", {
-    method: "POST",
-    body: JSON.stringify({ email }),
-  });
+  const response = await post("/api/v1/forgot-password", { email });
   await throwIfNotOk(response, "パスワード再設定メールの送信に失敗しました");
 };
 
 export const resetPassword = async (payload: ResetPasswordPayload): Promise<void> => {
   await getCsrfCookie();
-  const response = await apiClient("/api/v1/reset-password", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+  const response = await post("/api/v1/reset-password", payload);
   await throwIfNotOk(response, "パスワードのリセットに失敗しました");
 };

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "../../../shared/api/client";
+import { throwIfNotOk } from "../../../shared/api/error";
 import type { User } from "../types";
 
 export interface LoginPayload {
@@ -19,13 +20,6 @@ export interface ResetPasswordPayload {
   password: string;
   password_confirmation: string;
 }
-
-/** レスポンスが失敗の場合にサーバーメッセージ付きでエラーをスローする */
-const throwIfNotOk = async (response: Response, fallback: string): Promise<void> => {
-  if (response.ok) return;
-  const data = await response.json().catch(() => ({}));
-  throw new Error((data as { message?: string }).message ?? fallback);
-};
 
 export const getCsrfCookie = async (): Promise<void> => {
   await apiClient("/sanctum/csrf-cookie", { method: "GET" });

--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,5 +1,5 @@
 import { get, post } from "../../../shared/api/client";
-import { throwIfNotOk } from "../../../shared/api/error";
+import { fetchJson, throwIfNotOk } from "../../../shared/api/error";
 import type { User } from "../types";
 
 export interface LoginPayload {
@@ -46,8 +46,7 @@ export const logout = async (): Promise<void> => {
 export const getCurrentUser = async (): Promise<User | null> => {
   const response = await get("/api/v1/user");
   if (response.status === 401) return null;
-  await throwIfNotOk(response, "ユーザー情報の取得に失敗しました");
-  return response.json() as Promise<User>;
+  return fetchJson<User>(response, "ユーザー情報の取得に失敗しました");
 };
 
 export const verifyEmail = async (verifyUrl: string): Promise<void> => {
@@ -57,11 +56,8 @@ export const verifyEmail = async (verifyUrl: string): Promise<void> => {
 
 export const resendVerificationEmail = async (): Promise<"sent" | "already-verified"> => {
   const response = await post("/api/v1/email/verification-notification");
-  await throwIfNotOk(response, "確認メールの再送に失敗しました");
-  const data = await response.json().catch(() => ({}));
-  return (data as { status?: string }).status === "already-verified"
-    ? "already-verified"
-    : "sent";
+  const data = await fetchJson<{ status?: string }>(response, "確認メールの再送に失敗しました");
+  return data.status === "already-verified" ? "already-verified" : "sent";
 };
 
 export const sendPasswordResetLink = async (email: string): Promise<void> => {

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -34,3 +34,15 @@ export const apiClient = async (endpoint: string, options: RequestInit = {}) => 
 
   return response;
 };
+
+export const get = (endpoint: string, options: Omit<RequestInit, 'method'> = {}) =>
+  apiClient(endpoint, { ...options, method: 'GET' });
+
+export const post = (endpoint: string, body?: unknown, options: Omit<RequestInit, 'method' | 'body'> = {}) =>
+  apiClient(endpoint, { ...options, method: 'POST', body: body !== undefined ? JSON.stringify(body) : undefined });
+
+export const patch = (endpoint: string, body?: unknown, options: Omit<RequestInit, 'method' | 'body'> = {}) =>
+  apiClient(endpoint, { ...options, method: 'PATCH', body: body !== undefined ? JSON.stringify(body) : undefined });
+
+export const del = (endpoint: string, options: Omit<RequestInit, 'method'> = {}) =>
+  apiClient(endpoint, { ...options, method: 'DELETE' });

--- a/src/shared/api/error.ts
+++ b/src/shared/api/error.ts
@@ -1,0 +1,6 @@
+/** レスポンスが失敗の場合にサーバーメッセージ付きでエラーをスローする */
+export const throwIfNotOk = async (response: Response, fallback: string): Promise<void> => {
+  if (response.ok) return;
+  const data = await response.json().catch(() => ({}));
+  throw new Error((data as { message?: string }).message ?? fallback);
+};

--- a/src/shared/api/error.ts
+++ b/src/shared/api/error.ts
@@ -37,9 +37,9 @@ export class ApiError extends Error {
 export const isApiError = (error: unknown): error is ApiError =>
   error instanceof ApiError;
 
-/** レスポンスが失敗の場合にサーバーメッセージ付きでエラーをスローする */
+/** レスポンスが失敗の場合に ApiError をスローする */
 export const throwIfNotOk = async (response: Response, fallback: string): Promise<void> => {
   if (response.ok) return;
   const data: ErrorResponseBody = await response.json().catch(() => ({}));
-  throw new Error(data.message ?? fallback);
+  throw new ApiError(response.status, data.message ?? fallback, data.errors);
 };

--- a/src/shared/api/error.ts
+++ b/src/shared/api/error.ts
@@ -1,8 +1,9 @@
-export type ApiErrorType = 'unauthorized' | 'validation' | 'server' | 'unknown';
+export type ApiErrorType = 'unauthorized' | 'forbidden' | 'validation' | 'server' | 'unknown';
 
 /** HTTP ステータスコードからエラー種別を分類する */
 const classifyStatus = (status: number): ApiErrorType => {
   if (status === 401) return 'unauthorized';
+  if (status === 403) return 'forbidden';
   if (status === 422) return 'validation';
   if (status >= 500) return 'server';
   return 'unknown';
@@ -42,4 +43,13 @@ export const throwIfNotOk = async (response: Response, fallback: string): Promis
   if (response.ok) return;
   const data: ErrorResponseBody = await response.json().catch(() => ({}));
   throw new ApiError(response.status, data.message ?? fallback, data.errors);
+};
+
+/** レスポンスボディを一度だけ読み取り、失敗なら ApiError をスローして成功なら T を返す */
+export const fetchJson = async <T>(response: Response, fallback: string): Promise<T> => {
+  const data: ErrorResponseBody = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new ApiError(response.status, data.message ?? fallback, data.errors);
+  }
+  return data as T;
 };

--- a/src/shared/api/error.ts
+++ b/src/shared/api/error.ts
@@ -1,6 +1,45 @@
+export type ApiErrorType = 'unauthorized' | 'validation' | 'server' | 'unknown';
+
+/** HTTP ステータスコードからエラー種別を分類する */
+const classifyStatus = (status: number): ApiErrorType => {
+  if (status === 401) return 'unauthorized';
+  if (status === 422) return 'validation';
+  if (status >= 500) return 'server';
+  return 'unknown';
+};
+
+/** Laravel の標準エラーレスポンス形式 */
+interface ErrorResponseBody {
+  message?: string;
+  errors?: Record<string, string[]>;
+}
+
+/**
+ * API 通信で発生したエラーを表すクラス。
+ * - `status`: HTTP ステータスコード
+ * - `type`: エラー種別（unauthorized / validation / server / unknown）
+ * - `errors`: 422 バリデーションエラーの詳細（フィールド別）
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly type: ApiErrorType;
+  readonly errors: Record<string, string[]> | undefined;
+
+  constructor(status: number, message: string, errors?: Record<string, string[]>) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.type = classifyStatus(status);
+    this.errors = errors;
+  }
+}
+
+export const isApiError = (error: unknown): error is ApiError =>
+  error instanceof ApiError;
+
 /** レスポンスが失敗の場合にサーバーメッセージ付きでエラーをスローする */
 export const throwIfNotOk = async (response: Response, fallback: string): Promise<void> => {
   if (response.ok) return;
-  const data = await response.json().catch(() => ({}));
-  throw new Error((data as { message?: string }).message ?? fallback);
+  const data: ErrorResponseBody = await response.json().catch(() => ({}));
+  throw new Error(data.message ?? fallback);
 };


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

## 概要

`shared/api/` に `throwIfNotOk`・`ApiError`・メソッドショートハンドを整備し、`features/auth/api/auth.ts` をリファクタリングした。

## 対象 変更内容

1. `shared/api/error.ts`（新規）: `throwIfNotOk` を共通化、`ApiError` クラス・`isApiError` 型ガードを追加
2. `shared/api/client.ts`: `get` / `post` / `patch` / `del` ショートハンドを追加
3. `features/auth/api/auth.ts`: `apiClient` 直接呼び出しを `get`/`post` ショートハンドに移行、ローカルの `throwIfNotOk` を削除

## 変更の目的

- 全 feature API から `throwIfNotOk` を共通利用できるようにするため
- 401/422/500 のエラーを `ApiError.type` で型安全に分類・参照できるようにするため
- `apiClient` の `method` 指定・`JSON.stringify` を各呼び出し元で書かなくて済むようにするため

## 動作確認

- [x] `GET /sanctum/csrf-cookie` → `POST /api/v1/login` → `GET /api/v1/user` の CSRF フローが正常動作（curl で確認）
- [x] 未認証時に `GET /api/v1/user` が 401 を返すことを確認
- [x] 不正認証情報で `POST /api/v1/login` が 422 + `errors` フィールドを返すことを確認
- [x] TypeScript の型チェック（`tsc --noEmit`）がエラーなしで通過