### PR TITLE
feat: [16.1] グリッドレイアウト設計・CSS Grid 基本構造

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "^5.95.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "lucide-react": "^0.577.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2173,6 +2174,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.95.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.577.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/features/shift/components/PeriodLabel.tsx
+++ b/src/features/shift/components/PeriodLabel.tsx
@@ -1,0 +1,14 @@
+import type { ShiftPeriod } from '../types'
+import { formatPeriodLabel } from '../utils/formatPeriodLabel'
+
+interface PeriodLabelProps {
+  period: ShiftPeriod
+}
+
+export function PeriodLabel({ period }: PeriodLabelProps) {
+  return (
+    <div className="px-4 py-2 bg-gray-50 rounded-lg min-w-[200px] text-center text-gray-900">
+      {formatPeriodLabel(period)}
+    </div>
+  )
+}

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -13,7 +13,7 @@ export function ShiftGrid({ dates, staffRows }: ShiftGridProps) {
 
   return (
     <div className="overflow-x-auto bg-gray-50">
-      <div className="min-w-[1200px]" style={{ gridTemplateColumns }}>
+      <div className="min-w-[1200px]">
         {/* ヘッダー行 */}
         <div
           className="grid sticky top-0 z-10 bg-white border-b-2 border-gray-300"

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -13,7 +13,7 @@ export function ShiftGrid({ dates, staffRows }: ShiftGridProps) {
 
   return (
     <div className="overflow-x-auto bg-gray-50">
-      <div className="min-w-[1200px]">
+      <div className="w-max min-w-full">
         {/* ヘッダー行 */}
         <div
           className="grid sticky top-0 z-10 bg-white border-b-2 border-gray-300"

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -1,0 +1,58 @@
+import type { DateCell, StaffRow } from '../types'
+
+const STAFF_COL_WIDTH = '120px'
+const DATE_COL_MIN_WIDTH = '80px'
+
+interface ShiftGridProps {
+  dates: DateCell[]
+  staffRows: StaffRow[]
+}
+
+export function ShiftGrid({ dates, staffRows }: ShiftGridProps) {
+  const gridTemplateColumns = `${STAFF_COL_WIDTH} repeat(${dates.length}, minmax(${DATE_COL_MIN_WIDTH}, 1fr))`
+
+  return (
+    <div className="overflow-x-auto bg-gray-50">
+      <div className="min-w-[1200px]" style={{ gridTemplateColumns }}>
+        {/* ヘッダー行 */}
+        <div
+          className="grid sticky top-0 z-10 bg-white border-b-2 border-gray-300"
+          style={{ gridTemplateColumns }}
+        >
+          <div className="px-3 py-2 border-r border-gray-300 flex items-center">
+            <span className="text-xs text-gray-900">スタッフ名</span>
+          </div>
+          {dates.map((cell) => (
+            <div
+              key={cell.date.toISOString()}
+              className="px-2 py-2 border-r border-gray-200 text-center"
+            >
+              <span className="text-sm text-gray-900">
+                {cell.date.getDate()}日
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* スタッフ行 */}
+        {staffRows.map((staff) => (
+          <div
+            key={staff.id}
+            className="grid border-b border-gray-200 bg-white"
+            style={{ gridTemplateColumns }}
+          >
+            <div className="px-3 py-4 border-r border-gray-300 flex items-center">
+              <span className="text-xs text-gray-900 truncate">{staff.name}</span>
+            </div>
+            {dates.map((cell) => (
+              <div
+                key={cell.date.toISOString()}
+                className="h-16 border-r border-gray-200"
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/features/shift/hooks/usePeriodNavigation.ts
+++ b/src/features/shift/hooks/usePeriodNavigation.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { endOfMonth } from 'date-fns'
 import type { ShiftPeriod } from '../types'
+import { getCurrentPeriod } from '../utils/getCurrentPeriod'
 
 function isFirstHalf(period: ShiftPeriod): boolean {
   return period.from.getDate() <= 15
@@ -46,7 +47,7 @@ function getNextPeriod(current: ShiftPeriod): ShiftPeriod {
   }
 }
 
-export function usePeriodNavigation(initialPeriod: ShiftPeriod) {
+export function usePeriodNavigation(initialPeriod: ShiftPeriod = getCurrentPeriod()) {
   const [period, setPeriod] = useState<ShiftPeriod>(initialPeriod)
 
   const goToPrev = () => setPeriod((p) => getPrevPeriod(p))

--- a/src/features/shift/hooks/usePeriodNavigation.ts
+++ b/src/features/shift/hooks/usePeriodNavigation.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { endOfMonth } from 'date-fns'
+import type { ShiftPeriod } from '../types'
+
+function isFirstHalf(period: ShiftPeriod): boolean {
+  return period.from.getDate() <= 15
+}
+
+function getPrevPeriod(current: ShiftPeriod): ShiftPeriod {
+  const { from } = current
+  const year = from.getFullYear()
+  const month = from.getMonth()
+
+  if (isFirstHalf(current)) {
+    const prevMonth = month === 0 ? 11 : month - 1
+    const prevYear = month === 0 ? year - 1 : year
+    return {
+      from: new Date(prevYear, prevMonth, 16),
+      to: endOfMonth(new Date(prevYear, prevMonth, 1)),
+    }
+  }
+
+  return {
+    from: new Date(year, month, 1),
+    to: new Date(year, month, 15),
+  }
+}
+
+function getNextPeriod(current: ShiftPeriod): ShiftPeriod {
+  const { from } = current
+  const year = from.getFullYear()
+  const month = from.getMonth()
+
+  if (isFirstHalf(current)) {
+    return {
+      from: new Date(year, month, 16),
+      to: endOfMonth(new Date(year, month, 1)),
+    }
+  }
+
+  const nextMonth = month === 11 ? 0 : month + 1
+  const nextYear = month === 11 ? year + 1 : year
+  return {
+    from: new Date(nextYear, nextMonth, 1),
+    to: new Date(nextYear, nextMonth, 15),
+  }
+}
+
+export function usePeriodNavigation(initialPeriod: ShiftPeriod) {
+  const [period, setPeriod] = useState<ShiftPeriod>(initialPeriod)
+
+  const goToPrev = () => setPeriod((p) => getPrevPeriod(p))
+  const goToNext = () => setPeriod((p) => getNextPeriod(p))
+
+  return { period, goToPrev, goToNext }
+}

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -1,0 +1,14 @@
+export interface ShiftPeriod {
+  from: Date
+  to: Date
+}
+
+export interface DateCell {
+  date: Date
+  dayOfWeek: number
+}
+
+export interface StaffRow {
+  id: number
+  name: string
+}

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -1,14 +1,14 @@
 export interface ShiftPeriod {
-  from: Date
-  to: Date
+  from: Date;
+  to: Date;
 }
 
 export interface DateCell {
-  date: Date
-  dayOfWeek: number
+  date: Date;
+  dayOfWeek: number;
 }
 
 export interface StaffRow {
-  id: number
-  name: string
+  id: number;
+  name: string;
 }

--- a/src/features/shift/utils/formatPeriodLabel.ts
+++ b/src/features/shift/utils/formatPeriodLabel.ts
@@ -1,0 +1,10 @@
+import type { ShiftPeriod } from '../types'
+
+export function formatPeriodLabel(period: ShiftPeriod): string {
+  const { from } = period
+  const year = from.getFullYear()
+  const month = from.getMonth() + 1
+  const half = from.getDate() <= 15 ? '前半' : '後半'
+
+  return `${year}年${month}月 ${half}`
+}

--- a/src/features/shift/utils/generateDateRange.ts
+++ b/src/features/shift/utils/generateDateRange.ts
@@ -1,0 +1,9 @@
+import { eachDayOfInterval, getDay } from 'date-fns'
+import type { DateCell, ShiftPeriod } from '../types'
+
+export function generateDateRange(period: ShiftPeriod): DateCell[] {
+  return eachDayOfInterval({ start: period.from, end: period.to }).map((date) => ({
+    date,
+    dayOfWeek: getDay(date),
+  }))
+}

--- a/src/features/shift/utils/getCurrentPeriod.ts
+++ b/src/features/shift/utils/getCurrentPeriod.ts
@@ -1,0 +1,20 @@
+import { endOfMonth } from 'date-fns'
+import type { ShiftPeriod } from '../types'
+
+export function getCurrentPeriod(): ShiftPeriod {
+  const today = new Date()
+  const year = today.getFullYear()
+  const month = today.getMonth()
+
+  if (today.getDate() <= 15) {
+    return {
+      from: new Date(year, month, 1),
+      to: new Date(year, month, 15),
+    }
+  }
+
+  return {
+    from: new Date(year, month, 16),
+    to: endOfMonth(today),
+  }
+}

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -3,12 +3,7 @@ import { Button } from '../components/ui/button'
 import { ShiftGrid } from '../features/shift/components/ShiftGrid'
 import { usePeriodNavigation } from '../features/shift/hooks/usePeriodNavigation'
 import { generateDateRange } from '../features/shift/utils/generateDateRange'
-import type { ShiftPeriod, StaffRow } from '../features/shift/types'
-
-const INITIAL_PERIOD: ShiftPeriod = {
-  from: new Date(2026, 3, 1),
-  to: new Date(2026, 3, 15),
-}
+import type { StaffRow } from '../features/shift/types'
 
 const DUMMY_STAFF: StaffRow[] = [
   { id: 1, name: '田中 太郎' },
@@ -19,7 +14,7 @@ const DUMMY_STAFF: StaffRow[] = [
 ]
 
 export function AdminShiftsPage() {
-  const { period, goToPrev, goToNext } = usePeriodNavigation(INITIAL_PERIOD)
+  const { period, goToPrev, goToNext } = usePeriodNavigation()
   const dates = generateDateRange(period)
 
   return (

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -1,3 +1,24 @@
+import { ShiftGrid } from '../features/shift/components/ShiftGrid'
+import { generateDateRange } from '../features/shift/utils/generateDateRange'
+import type { ShiftPeriod, StaffRow } from '../features/shift/types'
+
+const DUMMY_PERIOD: ShiftPeriod = {
+  from: new Date(2026, 3, 1),
+  to: new Date(2026, 3, 15),
+}
+
+const DUMMY_STAFF: StaffRow[] = [
+  { id: 1, name: '田中 太郎' },
+  { id: 2, name: '佐藤 花子' },
+  { id: 3, name: '鈴木 一郎' },
+  { id: 4, name: '高橋 美咲' },
+  { id: 5, name: '渡辺 健太' },
+]
+
 export function AdminShiftsPage() {
-  return <p>ここにシフト一覧・編集 UI を配置します。</p>
+  const dates = generateDateRange(DUMMY_PERIOD)
+
+  return (
+    <ShiftGrid dates={dates} staffRows={DUMMY_STAFF} />
+  )
 }

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from '../components/ui/button'
+import { PeriodLabel } from '../features/shift/components/PeriodLabel'
 import { ShiftGrid } from '../features/shift/components/ShiftGrid'
 import { usePeriodNavigation } from '../features/shift/hooks/usePeriodNavigation'
 import { generateDateRange } from '../features/shift/utils/generateDateRange'
@@ -23,6 +24,7 @@ export function AdminShiftsPage() {
         <Button variant="outline" size="icon" onClick={goToPrev} aria-label="前の半月">
           <ChevronLeft className="w-4 h-4" />
         </Button>
+        <PeriodLabel period={period} />
         <Button variant="outline" size="icon" onClick={goToNext} aria-label="次の半月">
           <ChevronRight className="w-4 h-4" />
         </Button>

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -1,8 +1,11 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { Button } from '../components/ui/button'
 import { ShiftGrid } from '../features/shift/components/ShiftGrid'
+import { usePeriodNavigation } from '../features/shift/hooks/usePeriodNavigation'
 import { generateDateRange } from '../features/shift/utils/generateDateRange'
 import type { ShiftPeriod, StaffRow } from '../features/shift/types'
 
-const DUMMY_PERIOD: ShiftPeriod = {
+const INITIAL_PERIOD: ShiftPeriod = {
   from: new Date(2026, 3, 1),
   to: new Date(2026, 3, 15),
 }
@@ -16,9 +19,20 @@ const DUMMY_STAFF: StaffRow[] = [
 ]
 
 export function AdminShiftsPage() {
-  const dates = generateDateRange(DUMMY_PERIOD)
+  const { period, goToPrev, goToNext } = usePeriodNavigation(INITIAL_PERIOD)
+  const dates = generateDateRange(period)
 
   return (
-    <ShiftGrid dates={dates} staffRows={DUMMY_STAFF} />
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-center gap-3">
+        <Button variant="outline" size="icon" onClick={goToPrev} aria-label="前の半月">
+          <ChevronLeft className="w-4 h-4" />
+        </Button>
+        <Button variant="outline" size="icon" onClick={goToNext} aria-label="次の半月">
+          <ChevronRight className="w-4 h-4" />
+        </Button>
+      </div>
+      <ShiftGrid dates={dates} staffRows={DUMMY_STAFF} />
+    </div>
   )
 }


### PR DESCRIPTION
## 概要

シフト表グリッドの基本レイアウト（CSS Grid）と半月期間の切替ナビゲーションを実装した。

## 対象 変更内容

1. `features/shift/types/index.ts`（新規）：ShiftPeriod / DateCell / StaffRow 型定義
2. `features/shift/utils/generateDateRange.ts`（新規）：date-fns で from/to から DateCell[] を生成
3. `features/shift/utils/getCurrentPeriod.ts`（新規）：現在日付から今日の半月を自動判定
4. `features/shift/utils/formatPeriodLabel.ts`（新規）：「2026年5月 前半」形式の文字列を返す
5. `features/shift/hooks/usePeriodNavigation.ts`（新規）：半月単位の期間状態管理と前後ナビゲーション
6. `features/shift/components/ShiftGrid.tsx`（新規）：CSS Grid によるスタッフ名固定列 + 日付列のグリッド構造
7. `features/shift/components/PeriodLabel.tsx`（新規）：期間ラベル表示コンポーネント
8. `pages/AdminShiftsPage.tsx`（変更）：ShiftGrid・PeriodLabel・ナビゲーションボタンを組み込み

## 動作確認

- [ ] AdminShiftsPage を開くと現在の半月のシフトグリッドが表示される
- [ ] 「前の半月」「次の半月」ボタンで期間が切り替わる
- [ ] PeriodLabel に「2026年5月 前半」のような正しいラベルが表示される
- [ ] 横スクロールが機能し、1200px 未満の画面でもグリッドが崩れない