### PR TITLE
feat: [16.2] ヘッダー行（日付・曜日）実装

### DIFF
--- a/src/features/shift/components/DateHeaderRow.tsx
+++ b/src/features/shift/components/DateHeaderRow.tsx
@@ -1,0 +1,47 @@
+import { format, isToday } from 'date-fns'
+import type { DateCell } from '../types'
+
+const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'] as const
+
+interface DateHeaderRowProps {
+  dates: DateCell[]
+  gridTemplateColumns: string
+}
+
+export function DateHeaderRow({ dates, gridTemplateColumns }: DateHeaderRowProps) {
+  return (
+    <div
+      className="grid sticky top-0 z-10 bg-white border-b-2 border-gray-300"
+      style={{ gridTemplateColumns }}
+    >
+      <div className="px-3 py-2 border-r border-gray-300 flex items-center">
+        <span className="text-xs text-gray-900">スタッフ名</span>
+      </div>
+      {dates.map((cell) => {
+        const today = isToday(cell.date)
+        const isSunday = cell.dayOfWeek === 0
+        const isSaturday = cell.dayOfWeek === 6
+
+        const dateTextColor = isSunday
+          ? 'text-red-500'
+          : isSaturday
+            ? 'text-blue-500'
+            : 'text-gray-900'
+
+        return (
+          <div
+            key={cell.date.toISOString()}
+            className={`px-1 py-2 border-r border-gray-200 text-center${today ? ' bg-blue-50' : ''}`}
+          >
+            <div className={`text-xs font-medium ${dateTextColor}`}>
+              {format(cell.date, 'M/d')}
+            </div>
+            <div className={`text-xs ${dateTextColor}`}>
+              {DAY_LABELS[cell.dayOfWeek]}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -1,4 +1,5 @@
 import type { DateCell, StaffRow } from '../types'
+import { DateHeaderRow } from './DateHeaderRow'
 
 const STAFF_COL_WIDTH = '120px'
 const DATE_COL_MIN_WIDTH = '80px'
@@ -14,25 +15,7 @@ export function ShiftGrid({ dates, staffRows }: ShiftGridProps) {
   return (
     <div className="overflow-x-auto bg-gray-50">
       <div className="w-max min-w-full">
-        {/* ヘッダー行 */}
-        <div
-          className="grid sticky top-0 z-10 bg-white border-b-2 border-gray-300"
-          style={{ gridTemplateColumns }}
-        >
-          <div className="px-3 py-2 border-r border-gray-300 flex items-center">
-            <span className="text-xs text-gray-900">スタッフ名</span>
-          </div>
-          {dates.map((cell) => (
-            <div
-              key={cell.date.toISOString()}
-              className="px-2 py-2 border-r border-gray-200 text-center"
-            >
-              <span className="text-sm text-gray-900">
-                {cell.date.getDate()}日
-              </span>
-            </div>
-          ))}
-        </div>
+        <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} />
 
         {/* スタッフ行 */}
         {staffRows.map((staff) => (


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

## 概要

`ShiftGrid` にインラインで埋め込まれていたヘッダー行を `DateHeaderRow` コンポーネントとして切り出し、曜日表示・土日カラー・今日のハイライト機能を追加した。

## 対象 変更内容

1. `src/features/shift/components/DateHeaderRow.tsx`（新規）
2. `src/features/shift/components/ShiftGrid.tsx`（変更）

## 変更の目的

- インライン実装では曜日・今日ハイライトの拡張が困難なため独立コンポーネントに切り出し
- `gridTemplateColumns` を props で受け取ることで列幅の管理責任を `ShiftGrid` に残す設計

## 動作確認

- [x] ヘッダー行に「月/日」形式の日付が表示される
- [x] 各日付セルに曜日（日〜土）が表示される
- [x] 日曜は赤・土曜は青のテキスト色が適用される
- [x] 今日の日付セルに `bg-blue-50` のハイライトが付く
- [x] 前半・後半の期間切替でヘッダー行が正しく再描画される