### PR TITLE
feat: [16.3] スタッフ行・セル構造実装

### DIFF
--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -9,8 +9,13 @@ interface ShiftCellProps {
   shift?: ShiftData
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function ShiftCell({ staffId: _staffId, date: _date, shift: _shift }: ShiftCellProps) {
   return (
-    <div className="h-16 border-r border-gray-200 hover:bg-gray-100 cursor-pointer" />
+    // TODO: タスク 18.1.1 で onClick にシフト登録モーダルを開くハンドラを渡す
+    <button
+      type="button"
+      className="h-16 w-full border-r border-gray-200 hover:bg-gray-100 cursor-pointer"
+    />
   )
 }

--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -1,8 +1,11 @@
 import type { ShiftData } from '../types'
 
 interface ShiftCellProps {
+  // TODO: API接続タスク（Phase1）でシフト登録モーダルを開く際に使用
   staffId: number
+  // TODO: API接続タスク（Phase1）でシフト登録モーダルを開く際に使用
   date: Date
+  // TODO: シフトデータ表示タスク（Phase1）でセル内に開始・終了時刻を描画する際に使用
   shift?: ShiftData
 }
 

--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -1,0 +1,13 @@
+import type { ShiftData } from '../types'
+
+interface ShiftCellProps {
+  staffId: number
+  date: Date
+  shift?: ShiftData
+}
+
+export function ShiftCell({ staffId: _staffId, date: _date, shift: _shift }: ShiftCellProps) {
+  return (
+    <div className="h-16 border-r border-gray-200" />
+  )
+}

--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -8,6 +8,6 @@ interface ShiftCellProps {
 
 export function ShiftCell({ staffId: _staffId, date: _date, shift: _shift }: ShiftCellProps) {
   return (
-    <div className="h-16 border-r border-gray-200" />
+    <div className="h-16 border-r border-gray-200 hover:bg-gray-100 cursor-pointer" />
   )
 }

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -7,20 +7,20 @@ const DATE_COL_MIN_WIDTH = '80px'
 
 interface ShiftGridProps {
   dates: DateCell[]
-  staffRows: Staff[]
+  members: Staff[]
 }
 
-export function ShiftGrid({ dates, staffRows }: ShiftGridProps) {
+export function ShiftGrid({ dates, members }: ShiftGridProps) {
   const gridTemplateColumns = `${STAFF_COL_WIDTH} repeat(${dates.length}, minmax(${DATE_COL_MIN_WIDTH}, 1fr))`
 
   return (
     <div className="overflow-x-auto bg-gray-50">
       <div className="w-max min-w-full">
         <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} />
-        {staffRows.map((staff) => (
+        {members.map((member) => (
           <StaffRow
-            key={staff.id}
-            staff={staff}
+            key={member.id}
+            member={member}
             dates={dates}
             gridTemplateColumns={gridTemplateColumns}
           />

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -1,4 +1,4 @@
-import type { DateCell, StaffRow } from '../types'
+import type { DateCell, Staff } from '../types'
 import { DateHeaderRow } from './DateHeaderRow'
 
 const STAFF_COL_WIDTH = '120px'
@@ -6,7 +6,7 @@ const DATE_COL_MIN_WIDTH = '80px'
 
 interface ShiftGridProps {
   dates: DateCell[]
-  staffRows: StaffRow[]
+  staffRows: Staff[]
 }
 
 export function ShiftGrid({ dates, staffRows }: ShiftGridProps) {

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -1,5 +1,6 @@
 import type { DateCell, Staff } from '../types'
 import { DateHeaderRow } from './DateHeaderRow'
+import { StaffRow } from './StaffRow'
 
 const STAFF_COL_WIDTH = '120px'
 const DATE_COL_MIN_WIDTH = '80px'
@@ -16,24 +17,13 @@ export function ShiftGrid({ dates, staffRows }: ShiftGridProps) {
     <div className="overflow-x-auto bg-gray-50">
       <div className="w-max min-w-full">
         <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} />
-
-        {/* スタッフ行 */}
         {staffRows.map((staff) => (
-          <div
+          <StaffRow
             key={staff.id}
-            className="grid border-b border-gray-200 bg-white"
-            style={{ gridTemplateColumns }}
-          >
-            <div className="px-3 py-4 border-r border-gray-300 flex items-center">
-              <span className="text-xs text-gray-900 truncate">{staff.name}</span>
-            </div>
-            {dates.map((cell) => (
-              <div
-                key={cell.date.toISOString()}
-                className="h-16 border-r border-gray-200"
-              />
-            ))}
-          </div>
+            staff={staff}
+            dates={dates}
+            gridTemplateColumns={gridTemplateColumns}
+          />
         ))}
       </div>
     </div>

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -17,12 +17,13 @@ export function ShiftGrid({ dates, members }: ShiftGridProps) {
     <div className="overflow-x-auto bg-gray-50">
       <div className="w-max min-w-full">
         <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} />
-        {members.map((member) => (
+        {members.map((member, index) => (
           <StaffRow
             key={member.id}
             member={member}
             dates={dates}
             gridTemplateColumns={gridTemplateColumns}
+            isEven={index % 2 === 0}
           />
         ))}
       </div>

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -1,0 +1,26 @@
+import type { DateCell, StaffRow as StaffRowData } from '../types'
+
+interface StaffRowProps {
+  staff: StaffRowData
+  dates: DateCell[]
+  gridTemplateColumns: string
+}
+
+export function StaffRow({ staff, dates, gridTemplateColumns }: StaffRowProps) {
+  return (
+    <div
+      className="grid border-b border-gray-200 bg-white"
+      style={{ gridTemplateColumns }}
+    >
+      <div className="px-3 py-4 border-r border-gray-300 flex items-center min-w-0">
+        <span className="text-xs text-gray-900 truncate">{staff.name}</span>
+      </div>
+      {dates.map((cell) => (
+        <div
+          key={cell.date.toISOString()}
+          className="h-16 border-r border-gray-200"
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -2,24 +2,24 @@ import type { DateCell, Staff } from '../types'
 import { ShiftCell } from './ShiftCell'
 
 interface StaffRowProps {
-  staff: Staff
+  member: Staff
   dates: DateCell[]
   gridTemplateColumns: string
 }
 
-export function StaffRow({ staff, dates, gridTemplateColumns }: StaffRowProps) {
+export function StaffRow({ member, dates, gridTemplateColumns }: StaffRowProps) {
   return (
     <div
       className="grid border-b border-gray-200 bg-white"
       style={{ gridTemplateColumns }}
     >
-      <div className="px-3 py-4 border-r border-gray-300 flex items-center min-w-0">
-        <span className="text-xs text-gray-900 truncate">{staff.name}</span>
+      <div className="h-16 px-3 border-r border-gray-300 flex items-center min-w-0">
+        <span className="text-xs text-gray-900 truncate">{member.name}</span>
       </div>
       {dates.map((cell) => (
         <ShiftCell
           key={cell.date.toISOString()}
-          staffId={staff.id}
+          staffId={member.id}
           date={cell.date}
         />
       ))}

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -1,7 +1,8 @@
-import type { DateCell, StaffRow as StaffRowData } from '../types'
+import type { DateCell, Staff } from '../types'
+import { ShiftCell } from './ShiftCell'
 
 interface StaffRowProps {
-  staff: StaffRowData
+  staff: Staff
   dates: DateCell[]
   gridTemplateColumns: string
 }
@@ -16,9 +17,10 @@ export function StaffRow({ staff, dates, gridTemplateColumns }: StaffRowProps) {
         <span className="text-xs text-gray-900 truncate">{staff.name}</span>
       </div>
       {dates.map((cell) => (
-        <div
+        <ShiftCell
           key={cell.date.toISOString()}
-          className="h-16 border-r border-gray-200"
+          staffId={staff.id}
+          date={cell.date}
         />
       ))}
     </div>

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils'
 import type { DateCell, Staff } from '../types'
 import { ShiftCell } from './ShiftCell'
 
@@ -5,12 +6,13 @@ interface StaffRowProps {
   member: Staff
   dates: DateCell[]
   gridTemplateColumns: string
+  isEven: boolean
 }
 
-export function StaffRow({ member, dates, gridTemplateColumns }: StaffRowProps) {
+export function StaffRow({ member, dates, gridTemplateColumns, isEven }: StaffRowProps) {
   return (
     <div
-      className="grid border-b border-gray-200 bg-white"
+      className={cn('grid border-b border-gray-200', isEven ? 'bg-white' : 'bg-gray-50')}
       style={{ gridTemplateColumns }}
     >
       <div className="h-16 px-3 border-r border-gray-300 flex flex-col justify-center gap-0.5 min-w-0">

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -13,8 +13,11 @@ export function StaffRow({ member, dates, gridTemplateColumns }: StaffRowProps) 
       className="grid border-b border-gray-200 bg-white"
       style={{ gridTemplateColumns }}
     >
-      <div className="h-16 px-3 border-r border-gray-300 flex items-center min-w-0">
-        <span className="text-xs text-gray-900 truncate">{member.name}</span>
+      <div className="h-16 px-3 border-r border-gray-300 flex flex-col justify-center gap-0.5 min-w-0">
+        <span className="text-xs font-medium text-gray-900 truncate">{member.name}</span>
+        {member.position && (
+          <span className="text-[10px] text-gray-500 truncate">{member.position}</span>
+        )}
       </div>
       {dates.map((cell) => (
         <ShiftCell

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -8,7 +8,15 @@ export interface DateCell {
   dayOfWeek: number;
 }
 
-export interface StaffRow {
+export interface Staff {
   id: number;
   name: string;
+}
+
+export interface ShiftData {
+  id: number;
+  staffId: number;
+  date: Date;
+  startTime: string;
+  endTime: string;
 }

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -17,7 +17,7 @@ export interface Staff {
 export interface ShiftData {
   id: number;
   staffId: number;
-  date: Date;
+  date: string;
   startTime: string;
   endTime: string;
 }

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -11,6 +11,7 @@ export interface DateCell {
 export interface Staff {
   id: number;
   name: string;
+  position?: string;
 }
 
 export interface ShiftData {

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -4,9 +4,9 @@ import { PeriodLabel } from '../features/shift/components/PeriodLabel'
 import { ShiftGrid } from '../features/shift/components/ShiftGrid'
 import { usePeriodNavigation } from '../features/shift/hooks/usePeriodNavigation'
 import { generateDateRange } from '../features/shift/utils/generateDateRange'
-import type { StaffRow } from '../features/shift/types'
+import type { Staff } from '../features/shift/types'
 
-const DUMMY_STAFF: StaffRow[] = [
+const DUMMY_STAFF: Staff[] = [
   { id: 1, name: '田中 太郎' },
   { id: 2, name: '佐藤 花子' },
   { id: 3, name: '鈴木 一郎' },

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -7,11 +7,11 @@ import { generateDateRange } from '../features/shift/utils/generateDateRange'
 import type { Staff } from '../features/shift/types'
 
 const DUMMY_STAFF: Staff[] = [
-  { id: 1, name: '田中 太郎' },
-  { id: 2, name: '佐藤 花子' },
-  { id: 3, name: '鈴木 一郎' },
-  { id: 4, name: '高橋 美咲' },
-  { id: 5, name: '渡辺 健太' },
+  { id: 1, name: '田中 太郎', position: '店長' },
+  { id: 2, name: '佐藤 花子', position: 'ホール' },
+  { id: 3, name: '鈴木 一郎', position: 'キッチン' },
+  { id: 4, name: '高橋 美咲', position: 'ホール' },
+  { id: 5, name: '渡辺 健太', position: 'キッチン' },
 ]
 
 export function AdminShiftsPage() {

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -29,7 +29,7 @@ export function AdminShiftsPage() {
           <ChevronRight className="w-4 h-4" />
         </Button>
       </div>
-      <ShiftGrid dates={dates} staffRows={DUMMY_STAFF} />
+      <ShiftGrid dates={dates} members={DUMMY_STAFF} />
     </div>
   )
 }


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

## 概要

ShiftGrid のインライン行実装を `StaffRow` / `ShiftCell` コンポーネントに分離し、スタッフ名・ポジション表示・ゼブラストライプ・ホバーエフェクトを含む行・セル構造を実装した。

## 対象 変更内容

1. `ShiftCell.tsx`（新規）：staffId / date / shift? を props で受け取るシフトセルコンポーネント。`hover:bg-gray-100 cursor-pointer` でホバーエフェクトを付与。
2. `StaffRow.tsx`（新規）：スタッフ名セル（名前＋ポジション2段）＋シフトセル列から成る1行。`isEven` で行背景色をゼブラストライプに切り替え。
3. `ShiftGrid.tsx`（変更）：インライン行実装を `StaffRow` に差し替え。`gridTemplateColumns` を `DateHeaderRow` と同一パターンで渡す。
4. `types/index.ts`（変更）：`Staff` 型に `position?: string` と `ShiftData` 型を追加。
5. `AdminShiftsPage.tsx`（変更）：ダミーデータにポジション情報を追加。

## 変更の目的

- ShiftGrid の行・セル実装をコンポーネント分離することで、将来のシフトデータ表示・クリックハンドラ追加を各コンポーネント内で完結できる設計を確立する
- `hover:bg-gray-100` を採用した理由：`hover:bg-gray-50`（仕様値）はゼブラストライプの奇数行（`bg-gray-50`）で色差がゼロになりホバーが視認できないため

## 動作確認

- [x] `http://localhost:5175/shifts` でスタッフ行 × 日付列のグリッドが正しく描画される
- [x] スタッフ名セルに名前（`text-xs font-medium`）とポジション（`text-[10px] text-gray-500`）が2段表示される
- [x] 奇数・偶数行で背景色が交互に切り替わる（`bg-white` / `bg-gray-50`）
- [x] 日付セルのホバー時に `bg-gray-100` が適用され、`cursor-pointer` が表示される
- [x] `npx tsc --noEmit` でエラーなし