### PR TITLE
feat: [16.4] グリッド線・セル内時刻表示の基盤実装

### DIFF
--- a/src/features/shift/components/DateHeaderRow.tsx
+++ b/src/features/shift/components/DateHeaderRow.tsx
@@ -8,9 +8,10 @@ const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'] as const
 interface DateHeaderRowProps {
   dates: DateCell[]
   gridTemplateColumns: string
+  closedDays?: number[]
 }
 
-export function DateHeaderRow({ dates, gridTemplateColumns }: DateHeaderRowProps) {
+export function DateHeaderRow({ dates, gridTemplateColumns, closedDays = [] }: DateHeaderRowProps) {
   const currentDate = useCurrentDate()
 
   return (
@@ -25,6 +26,7 @@ export function DateHeaderRow({ dates, gridTemplateColumns }: DateHeaderRowProps
         const isCurrentDay = isSameDay(cell.date, currentDate)
         const isSunday = cell.dayOfWeek === 0
         const isSaturday = cell.dayOfWeek === 6
+        const isClosed = closedDays.includes(cell.dayOfWeek)
 
         const dateTextColor = isSunday
           ? 'text-red-500'
@@ -35,7 +37,10 @@ export function DateHeaderRow({ dates, gridTemplateColumns }: DateHeaderRowProps
         return (
           <div
             key={cell.date.toISOString()}
-            className={cn('px-1 py-2 border-r border-gray-200 text-center', isCurrentDay && 'bg-blue-50')}
+            className={cn(
+              'px-1 py-2 border-r border-gray-200 text-center',
+              isClosed ? 'bg-gray-100' : isCurrentDay ? 'bg-blue-50' : '',
+            )}
           >
             <div className={`text-xs font-medium ${dateTextColor}`}>
               {format(cell.date, 'M/d')}

--- a/src/features/shift/components/DateHeaderRow.tsx
+++ b/src/features/shift/components/DateHeaderRow.tsx
@@ -1,14 +1,14 @@
 import { format, isSameDay } from 'date-fns'
 import { cn } from '@/lib/utils'
 import { useCurrentDate } from '@/shared/hooks/useCurrentDate'
-import type { DateCell } from '../types'
+import type { DateCell, DayOfWeek } from '../types'
 
 const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'] as const
 
 interface DateHeaderRowProps {
   dates: DateCell[]
   gridTemplateColumns: string
-  closedDays?: number[]
+  closedDays?: DayOfWeek[]
 }
 
 export function DateHeaderRow({ dates, gridTemplateColumns, closedDays = [] }: DateHeaderRowProps) {

--- a/src/features/shift/components/DateHeaderRow.tsx
+++ b/src/features/shift/components/DateHeaderRow.tsx
@@ -39,7 +39,9 @@ export function DateHeaderRow({ dates, gridTemplateColumns, closedDays = [] }: D
             key={cell.date.toISOString()}
             className={cn(
               'px-1 py-2 border-r border-gray-200 text-center',
-              isClosed ? 'bg-gray-100' : isCurrentDay ? 'bg-blue-50' : '',
+              isCurrentDay && 'bg-blue-50',
+              // 店休日は今日ハイライトより優先して上書きする（Phase1仕様：店休日にはシフト不可）
+              isClosed && 'bg-gray-100',
             )}
           >
             <div className={`text-xs font-medium ${dateTextColor}`}>

--- a/src/features/shift/components/DateHeaderRow.tsx
+++ b/src/features/shift/components/DateHeaderRow.tsx
@@ -18,7 +18,7 @@ export function DateHeaderRow({ dates, gridTemplateColumns }: DateHeaderRowProps
       className="grid sticky top-0 z-10 bg-white border-b-2 border-gray-300"
       style={{ gridTemplateColumns }}
     >
-      <div className="px-3 py-2 border-r border-gray-300 flex items-center">
+      <div className="px-3 py-2 border-r-2 border-gray-300 flex items-center">
         <span className="text-xs text-gray-900">スタッフ名</span>
       </div>
       {dates.map((cell) => {

--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -17,9 +17,10 @@ export function ShiftCell({ staffId: _staffId, date: _date, shift: _shift, isClo
     // TODO: タスク 18.1.1 で onClick にシフト登録モーダルを開くハンドラを渡す
     <button
       type="button"
+      disabled={isClosed}
       className={cn(
-        'h-16 w-full border-r border-gray-200 cursor-pointer',
-        isClosed ? 'bg-gray-100 hover:bg-gray-200' : 'hover:bg-gray-100',
+        'h-16 w-full border-r border-gray-200',
+        isClosed ? 'bg-gray-100 cursor-not-allowed' : 'hover:bg-gray-100 cursor-pointer',
       )}
     />
   )

--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils'
 import type { ShiftData } from '../types'
 
 interface ShiftCellProps {
@@ -7,15 +8,19 @@ interface ShiftCellProps {
   date: Date
   // TODO: シフトデータ表示タスク（Phase1）でセル内に開始・終了時刻を描画する際に使用
   shift?: ShiftData
+  isClosed?: boolean
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function ShiftCell({ staffId: _staffId, date: _date, shift: _shift }: ShiftCellProps) {
+export function ShiftCell({ staffId: _staffId, date: _date, shift: _shift, isClosed = false }: ShiftCellProps) {
   return (
     // TODO: タスク 18.1.1 で onClick にシフト登録モーダルを開くハンドラを渡す
     <button
       type="button"
-      className="h-16 w-full border-r border-gray-200 hover:bg-gray-100 cursor-pointer"
+      className={cn(
+        'h-16 w-full border-r border-gray-200 cursor-pointer',
+        isClosed ? 'bg-gray-100 hover:bg-gray-200' : 'hover:bg-gray-100',
+      )}
     />
   )
 }

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -1,4 +1,4 @@
-import type { DateCell, Staff } from '../types'
+import type { DateCell, DayOfWeek, Staff } from '../types'
 import { DateHeaderRow } from './DateHeaderRow'
 import { StaffRow } from './StaffRow'
 
@@ -8,7 +8,7 @@ const DATE_COL_MIN_WIDTH = '80px'
 interface ShiftGridProps {
   dates: DateCell[]
   members: Staff[]
-  closedDays?: number[]
+  closedDays?: DayOfWeek[]
 }
 
 export function ShiftGrid({ dates, members, closedDays = [] }: ShiftGridProps) {

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -15,7 +15,7 @@ export function ShiftGrid({ dates, members }: ShiftGridProps) {
 
   return (
     <div className="overflow-x-auto bg-gray-50">
-      <div className="w-max min-w-full">
+      <div className="w-max min-w-full border-t border-l border-gray-200">
         <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} />
         {members.map((member, index) => (
           <StaffRow

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -8,15 +8,16 @@ const DATE_COL_MIN_WIDTH = '80px'
 interface ShiftGridProps {
   dates: DateCell[]
   members: Staff[]
+  closedDays?: number[]
 }
 
-export function ShiftGrid({ dates, members }: ShiftGridProps) {
+export function ShiftGrid({ dates, members, closedDays = [] }: ShiftGridProps) {
   const gridTemplateColumns = `${STAFF_COL_WIDTH} repeat(${dates.length}, minmax(${DATE_COL_MIN_WIDTH}, 1fr))`
 
   return (
     <div className="overflow-x-auto bg-gray-50">
       <div className="w-max min-w-full border-t border-l border-gray-200">
-        <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} />
+        <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} closedDays={closedDays} />
         {members.map((member, index) => (
           <StaffRow
             key={member.id}
@@ -24,6 +25,7 @@ export function ShiftGrid({ dates, members }: ShiftGridProps) {
             dates={dates}
             gridTemplateColumns={gridTemplateColumns}
             isEven={index % 2 === 0}
+            closedDays={closedDays}
           />
         ))}
       </div>

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils'
-import type { DateCell, Staff } from '../types'
+import type { DateCell, DayOfWeek, Staff } from '../types'
 import { ShiftCell } from './ShiftCell'
 
 interface StaffRowProps {
@@ -7,7 +7,7 @@ interface StaffRowProps {
   dates: DateCell[]
   gridTemplateColumns: string
   isEven: boolean
-  closedDays?: number[]
+  closedDays?: DayOfWeek[]
 }
 
 export function StaffRow({ member, dates, gridTemplateColumns, isEven, closedDays = [] }: StaffRowProps) {

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -15,7 +15,7 @@ export function StaffRow({ member, dates, gridTemplateColumns, isEven }: StaffRo
       className={cn('grid border-b border-gray-200', isEven ? 'bg-white' : 'bg-gray-50')}
       style={{ gridTemplateColumns }}
     >
-      <div className="h-16 px-3 border-r border-gray-300 flex flex-col justify-center gap-0.5 min-w-0">
+      <div className="h-16 px-3 border-r-2 border-gray-300 flex flex-col justify-center gap-0.5 min-w-0">
         <span className="text-xs font-medium text-gray-900 truncate">{member.name}</span>
         {member.position && (
           <span className="text-[10px] text-gray-500 truncate">{member.position}</span>

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -7,9 +7,10 @@ interface StaffRowProps {
   dates: DateCell[]
   gridTemplateColumns: string
   isEven: boolean
+  closedDays?: number[]
 }
 
-export function StaffRow({ member, dates, gridTemplateColumns, isEven }: StaffRowProps) {
+export function StaffRow({ member, dates, gridTemplateColumns, isEven, closedDays = [] }: StaffRowProps) {
   return (
     <div
       className={cn('grid border-b border-gray-200', isEven ? 'bg-white' : 'bg-gray-50')}
@@ -26,6 +27,7 @@ export function StaffRow({ member, dates, gridTemplateColumns, isEven }: StaffRo
           key={cell.date.toISOString()}
           staffId={member.id}
           date={cell.date}
+          isClosed={closedDays.includes(cell.dayOfWeek)}
         />
       ))}
     </div>

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -1,3 +1,5 @@
+export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
 export interface ShiftPeriod {
   from: Date;
   to: Date;
@@ -5,7 +7,7 @@ export interface ShiftPeriod {
 
 export interface DateCell {
   date: Date;
-  dayOfWeek: number;
+  dayOfWeek: DayOfWeek;
 }
 
 export interface Staff {

--- a/src/features/shift/utils/__tests__/formatShiftTime.test.ts
+++ b/src/features/shift/utils/__tests__/formatShiftTime.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { formatShiftTime } from "../formatShiftTime";
+
+describe("formatShiftTime", () => {
+  it("開始・終了が揃っている場合は 'HH:MM〜HH:MM' 形式を返す", () => {
+    expect(formatShiftTime("09:00", "18:00")).toBe("09:00〜18:00");
+  });
+
+  it("midnight 跨ぎ（終了 < 開始）はそのまま表示する", () => {
+    expect(formatShiftTime("22:00", "02:00")).toBe("22:00〜02:00");
+  });
+
+  it("startTime が null のとき null を返す", () => {
+    expect(formatShiftTime(null, "18:00")).toBeNull();
+  });
+
+  it("endTime が null のとき null を返す", () => {
+    expect(formatShiftTime("09:00", null)).toBeNull();
+  });
+
+  it("startTime が undefined のとき null を返す", () => {
+    expect(formatShiftTime(undefined, "18:00")).toBeNull();
+  });
+
+  it("endTime が undefined のとき null を返す", () => {
+    expect(formatShiftTime("09:00", undefined)).toBeNull();
+  });
+
+  it("startTime が空文字のとき null を返す", () => {
+    expect(formatShiftTime("", "18:00")).toBeNull();
+  });
+
+  it("endTime が空文字のとき null を返す", () => {
+    expect(formatShiftTime("09:00", "")).toBeNull();
+  });
+});

--- a/src/features/shift/utils/__tests__/formatShiftTime.test.ts
+++ b/src/features/shift/utils/__tests__/formatShiftTime.test.ts
@@ -33,4 +33,12 @@ describe("formatShiftTime", () => {
   it("endTime が空文字のとき null を返す", () => {
     expect(formatShiftTime("09:00", "")).toBeNull();
   });
+
+  it("両方が null のとき null を返す", () => {
+    expect(formatShiftTime(null, null)).toBeNull();
+  });
+
+  it("両方が undefined のとき null を返す", () => {
+    expect(formatShiftTime(undefined, undefined)).toBeNull();
+  });
 });

--- a/src/features/shift/utils/formatShiftTime.ts
+++ b/src/features/shift/utils/formatShiftTime.ts
@@ -1,0 +1,14 @@
+/**
+ * 開始・終了時刻を "HH:MM〜HH:MM" 形式にフォーマットする。
+ *
+ * - どちらかが null / undefined / 空文字の場合は null を返す
+ * - midnight 跨ぎ（終了 < 開始）はそのまま表示する（例: "22:00〜02:00"）
+ */
+export function formatShiftTime(
+  startTime: string | null | undefined,
+  endTime: string | null | undefined,
+): string | null {
+  if (!startTime || !endTime) return null
+
+  return `${startTime}〜${endTime}`
+}

--- a/src/features/shift/utils/generateDateRange.ts
+++ b/src/features/shift/utils/generateDateRange.ts
@@ -1,9 +1,9 @@
 import { eachDayOfInterval, getDay } from 'date-fns'
-import type { DateCell, ShiftPeriod } from '../types'
+import type { DateCell, DayOfWeek, ShiftPeriod } from '../types'
 
 export function generateDateRange(period: ShiftPeriod): DateCell[] {
   return eachDayOfInterval({ start: period.from, end: period.to }).map((date) => ({
     date,
-    dayOfWeek: getDay(date),
+    dayOfWeek: getDay(date) as DayOfWeek,
   }))
 }

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -14,6 +14,9 @@ const DUMMY_STAFF: Staff[] = [
   { id: 5, name: '渡辺 健太', position: 'キッチン' },
 ]
 
+// Phase1ダミー: 日曜（0）を定休日として設定（タスク17でAPIデータに差し替え）
+const CLOSED_DAYS: number[] = [0]
+
 export function AdminShiftsPage() {
   const { period, goToPrev, goToNext } = usePeriodNavigation()
   const dates = generateDateRange(period)
@@ -29,7 +32,7 @@ export function AdminShiftsPage() {
           <ChevronRight className="w-4 h-4" />
         </Button>
       </div>
-      <ShiftGrid dates={dates} members={DUMMY_STAFF} />
+      <ShiftGrid dates={dates} members={DUMMY_STAFF} closedDays={CLOSED_DAYS} />
     </div>
   )
 }

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -4,7 +4,7 @@ import { PeriodLabel } from '../features/shift/components/PeriodLabel'
 import { ShiftGrid } from '../features/shift/components/ShiftGrid'
 import { usePeriodNavigation } from '../features/shift/hooks/usePeriodNavigation'
 import { generateDateRange } from '../features/shift/utils/generateDateRange'
-import type { Staff } from '../features/shift/types'
+import type { DayOfWeek, Staff } from '../features/shift/types'
 
 const DUMMY_STAFF: Staff[] = [
   { id: 1, name: '田中 太郎', position: '店長' },
@@ -15,7 +15,7 @@ const DUMMY_STAFF: Staff[] = [
 ]
 
 // Phase1ダミー: 日曜（0）を定休日として設定（タスク17でAPIデータに差し替え）
-const CLOSED_DAYS: number[] = [0]
+const CLOSED_DAYS: DayOfWeek[] = [0]
 
 export function AdminShiftsPage() {
   const { period, goToPrev, goToNext } = usePeriodNavigation()


### PR DESCRIPTION
## 概要

シフト表の基盤を完成させるため、CSS Grid グリッド線の整備、時刻フォーマットロジックの共通化、店休日列のグレー背景・操作無効化を行いました。

## 変更内容

### 1. 曜日定義の厳格化と伝播
マジックナンバーとしての `number` 型を廃止し、ドメイン知識を反映した `DayOfWeek` 型を導入しました。

*   **キャストの最小化**: データ生成（`generateDateRange`）の入口でのみ型キャストを行い、以降の全コンポーネントでは型安全な状態でデータを渡す構成にしています。これにより、各所での不要な型チェックを削減しました。

### 2. 店休日制御の実装
店休日の動的なスタイリングを実装しました。

*   **店休日ロジック**: `closedDays` 配列に基づく一括制御を実装。該当する列は、背景色の変更（`bg-gray-100`）、クリックイベントの無効化（`disabled`）とカーソル制御を行い、誤操作を防いでいます。

### 3. 表示ユーティリティの整備
*   **時刻フォーマット**: `formatShiftTime` を新規作成。`null` / `undefined` の安全な処理に加え、深夜を跨ぐ時間帯（例: 22:00〜02:00）の表示にも対応しています。

## 今回スコープ外

- `closedDays` の API 接続はタスク17で実施予定。現時点はダミー定義で動作確認する

## 動作確認

- [x] TypeScript エラーなし（`npx tsc --noEmit`）
- [x] グリッド外枠（上辺・左辺）が `border-t border-l border-gray-200` で閉じていること
- [x] ヘッダー下辺（`border-b-2`）> スタッフ名列右辺（`border-r-2`）> データセル（`border-r`）の3段階ボーダー階層が定義されていること
- [x] `closedDays = [0]` で日曜列のヘッダー・全データセルに `bg-gray-100` が適用されていること
- [x] 閉店日セルはクリック不可（`disabled`）かつカーソルが `not-allowed` になること
- [x] `formatShiftTime(null, "09:00")` が `null` を返すこと
- [x] `formatShiftTime("22:00", "02:00")` が `"22:00〜02:00"` を返すこと（midnight 跨ぎ）