### PR TITLE
fix: [17.0] PR #30 コードレビュー対応（LogoutModal・Sidebar・RouteGuardテスト）

### DIFF
--- a/src/features/auth/components/LogoutModal.tsx
+++ b/src/features/auth/components/LogoutModal.tsx
@@ -31,7 +31,10 @@ export function LogoutModal({ open, onClose }: LogoutModalProps) {
     <AlertDialog.Root
       open={open}
       onOpenChange={(isOpen) => {
-        if (!isOpen && !isPending) onClose()
+        if (!isOpen && !isPending) {
+          setErrorMessage(null)
+          onClose()
+        }
       }}
     >
       <AlertDialog.Portal>

--- a/src/features/auth/components/LogoutModal.tsx
+++ b/src/features/auth/components/LogoutModal.tsx
@@ -16,6 +16,11 @@ export function LogoutModal({ open, onClose }: LogoutModalProps) {
   const { mutate: logout, isPending } = useLogout()
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
+  const handleClose = () => {
+    setErrorMessage(null)
+    onClose()
+  }
+
   const handleLogout = () => {
     setErrorMessage(null)
     logout(undefined, {
@@ -31,10 +36,7 @@ export function LogoutModal({ open, onClose }: LogoutModalProps) {
     <AlertDialog.Root
       open={open}
       onOpenChange={(isOpen) => {
-        if (!isOpen && !isPending) {
-          setErrorMessage(null)
-          onClose()
-        }
+        if (!isOpen && !isPending) handleClose()
       }}
     >
       <AlertDialog.Portal>
@@ -57,7 +59,7 @@ export function LogoutModal({ open, onClose }: LogoutModalProps) {
             <p className="text-sm text-red-600 mb-4">{errorMessage}</p>
           )}
           <div className="flex gap-3 justify-end">
-            <Button variant="outline" onClick={onClose} disabled={isPending}>
+            <Button variant="outline" onClick={handleClose} disabled={isPending}>
               キャンセル
             </Button>
             <Button

--- a/src/routes/__tests__/RouteGuard.test.tsx
+++ b/src/routes/__tests__/RouteGuard.test.tsx
@@ -1,127 +1,182 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
-import { createMemoryRouter, RouterProvider } from 'react-router-dom'
-import { RouteGuard } from '../RouteGuard'
-import * as useAuthModule from '../../features/auth/hooks/useAuth'
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { RouteGuard } from "../RouteGuard";
+import * as useAuthModule from "../../features/auth/hooks/useAuth";
 
-vi.mock('../../features/auth/hooks/useAuth')
+vi.mock("../../features/auth/hooks/useAuth");
 
-const mockUseAuth = vi.mocked(useAuthModule.useAuth)
+const mockUseAuth = vi.mocked(useAuthModule.useAuth);
 
-function createRouter(access: 'protected' | 'protected-verified' | 'guest', initialPath = '/') {
+function createRouter(
+  access: "protected" | "protected-verified" | "guest",
+  initialPath = "/",
+) {
   return createMemoryRouter(
     [
       {
-        path: '/',
+        path: "/",
         element: <RouteGuard access={access} />,
         children: [{ index: true, element: <div>保護コンテンツ</div> }],
       },
-      { path: '/login', element: <div>ログインページ</div> },
-      { path: '/admin/shifts', element: <div>シフトページ</div> },
-      { path: '/verify-pending', element: <div>メール認証待ちページ</div> },
+      { path: "/login", element: <div>ログインページ</div> },
+      { path: "/admin/shifts", element: <div>シフトページ</div> },
+      { path: "/verify-pending", element: <div>メール認証待ちページ</div> },
     ],
     { initialEntries: [initialPath] },
-  )
+  );
 }
 
-describe('RouteGuard', () => {
+describe("RouteGuard", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   afterEach(() => {
-    cleanup()
-  })
+    cleanup();
+  });
 
   describe('access="protected"', () => {
-    it('isLoading 中はローディングUIを表示する', () => {
+    it("isLoading 中はローディングUIを表示する", () => {
       mockUseAuth.mockReturnValue({
         isAuthenticated: false,
         isEmailVerified: false,
         isLoading: true,
         isError: false,
         user: null,
-      })
+      });
 
-      render(<RouterProvider router={createRouter('protected')} />)
+      render(<RouterProvider router={createRouter("protected")} />);
 
-      expect(screen.getByText('認証情報を確認中...')).toBeInTheDocument()
-      expect(screen.queryByText('保護コンテンツ')).not.toBeInTheDocument()
-    })
+      expect(screen.getByText("認証情報を確認中...")).toBeInTheDocument();
+      expect(screen.queryByText("保護コンテンツ")).not.toBeInTheDocument();
+    });
 
-    it('isError 時はエラーUIを表示し Outlet を描画しない', () => {
+    it("isError 時はエラーUIを表示し Outlet を描画しない", () => {
       mockUseAuth.mockReturnValue({
         isAuthenticated: false,
         isEmailVerified: false,
         isLoading: false,
         isError: true,
         user: null,
-      })
+      });
 
-      render(<RouterProvider router={createRouter('protected')} />)
+      render(<RouterProvider router={createRouter("protected")} />);
 
-      expect(screen.getByText('ネットワークエラーが発生しました。接続を確認してください。')).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: 'ログインページへ' })).toBeInTheDocument()
-      expect(screen.queryByText('保護コンテンツ')).not.toBeInTheDocument()
-    })
+      expect(
+        screen.getByText(
+          "ネットワークエラーが発生しました。接続を確認してください。",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "ログインページへ" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("保護コンテンツ")).not.toBeInTheDocument();
+    });
 
-    it('未認証（isError なし）の場合は /login にリダイレクトする', () => {
+    it("未認証（isError なし）の場合は /login にリダイレクトする", () => {
       mockUseAuth.mockReturnValue({
         isAuthenticated: false,
         isEmailVerified: false,
         isLoading: false,
         isError: false,
         user: null,
-      })
+      });
 
-      render(<RouterProvider router={createRouter('protected')} />)
+      render(<RouterProvider router={createRouter("protected")} />);
 
-      expect(screen.getByText('ログインページ')).toBeInTheDocument()
-      expect(screen.queryByText('保護コンテンツ')).not.toBeInTheDocument()
-    })
+      expect(screen.getByText("ログインページ")).toBeInTheDocument();
+      expect(screen.queryByText("保護コンテンツ")).not.toBeInTheDocument();
+    });
 
-    it('認証済みの場合は Outlet を表示する', () => {
+    it("認証済みの場合は Outlet を表示する", () => {
       mockUseAuth.mockReturnValue({
         isAuthenticated: true,
         isEmailVerified: true,
         isLoading: false,
         isError: false,
-        user: { id: 1, name: 'テストユーザー', email: 'test@example.com' },
-      })
+        user: { id: 1, name: "テストユーザー", email: "test@example.com" },
+      });
 
-      render(<RouterProvider router={createRouter('protected')} />)
+      render(<RouterProvider router={createRouter("protected")} />);
 
-      expect(screen.getByText('保護コンテンツ')).toBeInTheDocument()
-    })
-  })
+      expect(screen.getByText("保護コンテンツ")).toBeInTheDocument();
+    });
+  });
+
+  describe('access="protected-verified"', () => {
+    it("未認証の場合は /login にリダイレクトする", () => {
+      mockUseAuth.mockReturnValue({
+        isAuthenticated: false,
+        isEmailVerified: false,
+        isLoading: false,
+        isError: false,
+        user: null,
+      });
+
+      render(<RouterProvider router={createRouter("protected-verified")} />);
+
+      expect(screen.getByText("ログインページ")).toBeInTheDocument();
+      expect(screen.queryByText("保護コンテンツ")).not.toBeInTheDocument();
+    });
+
+    it("認証済みだがメール未認証の場合は /verify-pending にリダイレクトする", () => {
+      mockUseAuth.mockReturnValue({
+        isAuthenticated: true,
+        isEmailVerified: false,
+        isLoading: false,
+        isError: false,
+        user: { id: 1, name: "テストユーザー", email: "test@example.com" },
+      });
+
+      render(<RouterProvider router={createRouter("protected-verified")} />);
+
+      expect(screen.getByText("メール認証待ちページ")).toBeInTheDocument();
+      expect(screen.queryByText("保護コンテンツ")).not.toBeInTheDocument();
+    });
+
+    it("認証済みかつメール認証済みの場合は Outlet を表示する", () => {
+      mockUseAuth.mockReturnValue({
+        isAuthenticated: true,
+        isEmailVerified: true,
+        isLoading: false,
+        isError: false,
+        user: { id: 1, name: "テストユーザー", email: "test@example.com" },
+      });
+
+      render(<RouterProvider router={createRouter("protected-verified")} />);
+
+      expect(screen.getByText("保護コンテンツ")).toBeInTheDocument();
+    });
+  });
 
   describe('access="guest"', () => {
-    it('認証済みの場合は /admin/shifts にリダイレクトする', () => {
+    it("認証済みの場合は /admin/shifts にリダイレクトする", () => {
       mockUseAuth.mockReturnValue({
         isAuthenticated: true,
         isEmailVerified: true,
         isLoading: false,
         isError: false,
-        user: { id: 1, name: 'テストユーザー', email: 'test@example.com' },
-      })
+        user: { id: 1, name: "テストユーザー", email: "test@example.com" },
+      });
 
-      render(<RouterProvider router={createRouter('guest')} />)
+      render(<RouterProvider router={createRouter("guest")} />);
 
-      expect(screen.getByText('シフトページ')).toBeInTheDocument()
-    })
+      expect(screen.getByText("シフトページ")).toBeInTheDocument();
+    });
 
-    it('未認証の場合は Outlet を表示する', () => {
+    it("未認証の場合は Outlet を表示する", () => {
       mockUseAuth.mockReturnValue({
         isAuthenticated: false,
         isEmailVerified: false,
         isLoading: false,
         isError: false,
         user: null,
-      })
+      });
 
-      render(<RouterProvider router={createRouter('guest')} />)
+      render(<RouterProvider router={createRouter("guest")} />);
 
-      expect(screen.getByText('保護コンテンツ')).toBeInTheDocument()
-    })
-  })
-})
+      expect(screen.getByText("保護コンテンツ")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/shared/components/layout/Sidebar.tsx
+++ b/src/shared/components/layout/Sidebar.tsx
@@ -1,16 +1,16 @@
-import { NavLink } from 'react-router-dom'
-import { LogOut, type LucideIcon } from 'lucide-react'
-import { cn } from '../../../lib/utils'
+import { NavLink } from "react-router-dom";
+import { LogOut, type LucideIcon } from "lucide-react";
+import { cn } from "../../../lib/utils";
 
 interface SidebarItem {
-  to: string
-  label: string
-  icon: LucideIcon
+  to: string;
+  label: string;
+  icon: LucideIcon;
 }
 
 interface SidebarProps {
-  items: SidebarItem[]
-  onLogoutClick: () => void
+  items: SidebarItem[];
+  onLogoutClick: () => void;
 }
 
 export function Sidebar({ items, onLogoutClick }: SidebarProps) {
@@ -24,8 +24,10 @@ export function Sidebar({ items, onLogoutClick }: SidebarProps) {
             aria-label={label}
             className={({ isActive }) =>
               cn(
-                'w-full flex items-center justify-center px-2 py-3 rounded-lg transition-colors',
-                isActive ? 'bg-blue-50 text-blue-600' : 'text-gray-700 hover:bg-gray-50'
+                "w-full flex items-center justify-center px-2 py-3 rounded-lg transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                isActive
+                  ? "bg-blue-50 text-blue-600"
+                  : "text-gray-700 hover:bg-gray-50",
               )
             }
           >
@@ -36,13 +38,14 @@ export function Sidebar({ items, onLogoutClick }: SidebarProps) {
 
       <div className="p-2 border-t border-gray-200">
         <button
+          type="button"
           onClick={onLogoutClick}
           aria-label="ログアウト"
-          className="w-full flex items-center justify-center px-2 py-3 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors"
+          className="w-full flex items-center justify-center px-2 py-3 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
         >
           <LogOut className="w-5 h-5" aria-hidden="true" />
         </button>
       </div>
     </aside>
-  )
+  );
 }


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

## 概要

PR #30 のマージ後に Copilot レビューで指摘された未解決コメント3件に対応しました。バグ修正・アクセシビリティ補完・テスト追加が主な変更内容です。

## 変更内容

1. **LogoutModal: クローズ時のエラーメッセージ残留を修正**（17.0.14）
   ログアウト失敗後にモーダルを閉じ再度開くと前回のエラーが表示されるバグを修正しました。

   - **修正箇所**: `onOpenChange` の `!isOpen && !isPending` ブランチで `onClose()` の前に `setErrorMessage(null)` を追加
   - **原因**: `AlertDialog.Root` は controlled mode のためコンポーネントがアンマウントされず、`onClose` 時に `errorMessage` がリセットされなかった
   - **効果**: 再オープン時に常てクリーンな状態でモーダルが表示されるようになった

2. **Sidebar: フォーカスインジケータ追加・`type="button"` 明示**（17.0.15）
   アイコン専用ナビのキーボード操作時にフォーカス位置が視認できなかった点を修正しました。

   - **NavLink**: `outline-none focus-visible:ring-3 focus-visible:ring-ring/50` を追加（`button.tsx` のデザイントークンと統一）
   - **ログアウトボタン**: 同じ `focus-visible` クラスを追加し、`type="button"` を明示（フォーム内での意図しない submit を防止）

3. **RouteGuard.test: `access="protected-verified"` 分岐テストを追加**（17.0.16）
   - **追加ケース**: 未認証→`/login`・認証済み未メール認証→`/verify-pending`・認証済みメール認証済み→Outlet 表示

## 動作確認

- [x] LogoutModal: ログアウト失敗後にモーダルを閉じ、再度開いてもエラーメッセージが表示されないこと
- [x] Sidebar: Tab キーでナビ・ログアウトボタンにフォーカスを当てるとリングが表示されること
- [x] RouteGuard テスト: `npx vitest run src/routes/__tests__/RouteGuard.test.tsx` で9件全パス