### PR TITLE
17.0 ログインページのデザイン刷新

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,14 +1,15 @@
-import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary/85 cursor-pointer",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
@@ -37,8 +38,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -52,7 +53,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useLogin } from '../hooks/useLogin';
@@ -13,6 +14,7 @@ import {
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
+import { PATHS } from '@/routes/paths';
 
 interface LoginFormProps {
   onLoginSuccess: () => void;
@@ -36,13 +38,13 @@ export const LoginForm = ({ onLoginSuccess }: LoginFormProps) => {
   };
 
   return (
-    <Card className="w-full max-w-md">
+    <Card className="w-full">
       <CardHeader>
         <CardTitle>ログイン</CardTitle>
         <CardDescription>登録済みメールアドレスでログインしてください。</CardDescription>
       </CardHeader>
       <Separator />
-      <CardContent>
+      <CardContent className="pt-6 pb-8 px-8">
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-1.5">
             <label htmlFor="login-email" className="block text-sm font-medium">メールアドレス</label>
@@ -76,6 +78,11 @@ export const LoginForm = ({ onLoginSuccess }: LoginFormProps) => {
           >
             {isPending ? '送信中...' : 'ログイン'}
           </Button>
+          <div className="text-center">
+            <Link to={PATHS.RESET_PASSWORD} className="text-sm text-primary hover:underline">
+              パスワードをお忘れですか？
+            </Link>
+          </div>
         </form>
       </CardContent>
     </Card>

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,20 +1,15 @@
-import { useState } from 'react';
-import { Link } from 'react-router-dom';
-import { useForm, type SubmitHandler } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useLogin } from '../hooks/useLogin';
-import { loginSchema, type LoginFormValues } from '../schemas/loginSchema';
-import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Separator } from '@/components/ui/separator';
-import { PATHS } from '@/routes/paths';
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useLogin } from "../hooks/useLogin";
+import { loginSchema, type LoginFormValues } from "../schemas/loginSchema";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { PATHS } from "@/routes/paths";
+
+const SAVED_EMAIL_KEY = "shifty_saved_email";
 
 interface LoginFormProps {
   onLoginSuccess: () => void;
@@ -22,15 +17,30 @@ interface LoginFormProps {
 
 export const LoginForm = ({ onLoginSuccess }: LoginFormProps) => {
   const [serverError, setServerError] = useState<string | null>(null);
+  const [rememberEmail, setRememberEmail] = useState(false);
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors },
   } = useForm<LoginFormValues>({ resolver: zodResolver(loginSchema) });
   const { mutate: login, isPending } = useLogin();
 
+  useEffect(() => {
+    const saved = localStorage.getItem(SAVED_EMAIL_KEY);
+    if (saved) {
+      setValue("email", saved);
+      setRememberEmail(true);
+    }
+  }, [setValue]);
+
   const onSubmit: SubmitHandler<LoginFormValues> = (data) => {
     setServerError(null);
+    if (rememberEmail) {
+      localStorage.setItem(SAVED_EMAIL_KEY, data.email);
+    } else {
+      localStorage.removeItem(SAVED_EMAIL_KEY);
+    }
     login(data, {
       onSuccess: onLoginSuccess,
       onError: (error) => setServerError(error.message),
@@ -38,48 +48,79 @@ export const LoginForm = ({ onLoginSuccess }: LoginFormProps) => {
   };
 
   return (
-    <Card className="w-full">
-      <CardHeader>
-        <CardTitle>ログイン</CardTitle>
-        <CardDescription>登録済みメールアドレスでログインしてください。</CardDescription>
-      </CardHeader>
-      <Separator />
-      <CardContent className="pt-6 pb-8 px-8">
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <div className="space-y-1.5">
-            <label htmlFor="login-email" className="block text-sm font-medium">メールアドレス</label>
+    <Card className="w-full py-0 shadow-lg bg-gray-50">
+      <CardContent className="p-10">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+          <div className="space-y-2">
+            <label
+              htmlFor="login-email"
+              className="block text-base font-medium text-gray-600"
+            >
+              メールアドレス
+            </label>
             <Input
               id="login-email"
               type="email"
+              placeholder="メールアドレスを入力"
+              className="h-11 bg-white placeholder:text-gray-400 md:text-base"
               disabled={isPending}
-              {...register('email')}
+              {...register("email")}
             />
             {errors.email && (
               <p className="text-sm text-destructive">{errors.email.message}</p>
             )}
           </div>
-          <div className="space-y-1.5">
-            <label htmlFor="login-password" className="block text-sm font-medium">パスワード</label>
+          <div className="space-y-2">
+            <label
+              htmlFor="login-password"
+              className="block text-base font-medium text-gray-600"
+            >
+              パスワード
+            </label>
             <Input
               id="login-password"
               type="password"
+              placeholder="パスワードを入力"
+              className="h-11 bg-white placeholder:text-gray-400 md:text-base"
               disabled={isPending}
-              {...register('password')}
+              {...register("password")}
             />
             {errors.password && (
-              <p className="text-sm text-destructive">{errors.password.message}</p>
+              <p className="text-sm text-destructive">
+                {errors.password.message}
+              </p>
             )}
           </div>
-          {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+          <div className="flex items-center gap-2">
+            <input
+              id="remember-email"
+              type="checkbox"
+              checked={rememberEmail}
+              onChange={(e) => setRememberEmail(e.target.checked)}
+              className="w-4 h-4 accent-primary cursor-pointer"
+            />
+            <label
+              htmlFor="remember-email"
+              className="text-sm text-gray-500 cursor-pointer select-none"
+            >
+              次回からメールアドレスの入力を省略
+            </label>
+          </div>
+          {serverError && (
+            <p className="text-sm text-destructive">{serverError}</p>
+          )}
           <Button
             type="submit"
             disabled={isPending}
-            className="w-full"
+            className="w-full h-11 text-base font-semibold text-white"
           >
-            {isPending ? '送信中...' : 'ログイン'}
+            {isPending ? "送信中..." : "ログイン"}
           </Button>
           <div className="text-center">
-            <Link to={PATHS.RESET_PASSWORD} className="text-sm text-primary hover:underline">
+            <Link
+              to={PATHS.RESET_PASSWORD}
+              className="text-sm text-gray-500 hover:text-primary hover:underline"
+            >
               パスワードをお忘れですか？
             </Link>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @theme {
   --font-sans: "Inter", system-ui, -apple-system, sans-serif;
   --font-heading: var(--font-sans);
-  --color-background: #f5f7fb;
+  --color-background: #ffffff;
   --color-foreground: #162033;
   --color-surface: #ffffff;
   --color-surface-foreground: #162033;
@@ -12,8 +12,8 @@
   --color-muted: #e7edf5;
   --color-muted-foreground: #5b6780;
   --color-border: #d6deea;
-  --color-input: var(--color-border);
-  --color-primary: #2563eb;
+  --color-input: #d1d5db;
+  --color-primary: #3b82f6;
   --color-primary-foreground: #eff6ff;
   --color-ring: var(--color-primary);
   --color-secondary: var(--color-muted);
@@ -24,9 +24,9 @@
   --color-danger-foreground: #fef2f2;
   --color-destructive: var(--color-danger);
   --color-destructive-foreground: var(--color-danger-foreground);
-  --radius-sm: 0.5rem;
-  --radius-md: 0.875rem;
-  --radius-lg: 1.25rem;
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
 }
 
 :root {
@@ -54,14 +54,7 @@ body {
   min-width: 320px;
   min-height: 100vh;
   color: var(--color-foreground);
-  background:
-    radial-gradient(circle at top, rgb(37 99 235 / 0.12), transparent 40%),
-    linear-gradient(
-      180deg,
-      #fbfdff 0%,
-      var(--color-background) 55%,
-      #eef3f9 100%
-    );
+  background-color: var(--color-background);
 }
 
 #root {
@@ -76,13 +69,15 @@ a:hover {
   color: #1d4ed8;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  margin: 0;
-  font-weight: 700;
-  line-height: 1.2;
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0;
+    font-weight: 700;
+    line-height: 1.2;
+  }
 }

--- a/src/layouts/AuthLayout.tsx
+++ b/src/layouts/AuthLayout.tsx
@@ -1,9 +1,14 @@
-import { Outlet } from 'react-router-dom'
+import { Outlet } from "react-router-dom";
 
 export function AuthLayout() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <Outlet />
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <main className="flex-1 flex items-center justify-center px-4 py-12">
+        <Outlet />
+      </main>
+      <footer className="bg-gray-200 border-t border-gray-300 py-4 px-6">
+        <p className="text-center text-sm text-gray-500">© 2025 Shifty</p>
+      </footer>
     </div>
-  )
+  );
 }

--- a/src/layouts/AuthLayout.tsx
+++ b/src/layouts/AuthLayout.tsx
@@ -7,7 +7,7 @@ export function AuthLayout() {
         <Outlet />
       </main>
       <footer className="bg-gray-100 border-t border-gray-200 py-6 px-6">
-        <div className="flex items-center justify-between px-[25%]">
+        <div className="flex items-center justify-between max-w-3xl mx-auto w-full px-4">
           <p className="text-sm text-gray-500">© {new Date().getFullYear()} Shifty</p>
           <div className="flex gap-4">
             <a href="#" className="text-sm text-gray-500 hover:text-gray-700">利用規約</a>

--- a/src/layouts/AuthLayout.tsx
+++ b/src/layouts/AuthLayout.tsx
@@ -2,12 +2,18 @@ import { Outlet } from "react-router-dom";
 
 export function AuthLayout() {
   return (
-    <div className="min-h-screen flex flex-col bg-gray-50">
+    <div className="min-h-screen flex flex-col">
       <main className="flex-1 flex items-center justify-center px-4 py-12">
         <Outlet />
       </main>
-      <footer className="bg-gray-200 border-t border-gray-300 py-4 px-6">
-        <p className="text-center text-sm text-gray-500">© 2025 Shifty</p>
+      <footer className="bg-gray-100 border-t border-gray-200 py-6 px-6">
+        <div className="flex items-center justify-between px-[25%]">
+          <p className="text-sm text-gray-500">© {new Date().getFullYear()} Shifty</p>
+          <div className="flex gap-4">
+            <a href="#" className="text-sm text-gray-500 hover:text-gray-700">利用規約</a>
+            <a href="#" className="text-sm text-gray-500 hover:text-gray-700">プライバシーポリシー</a>
+          </div>
+        </div>
       </footer>
     </div>
   );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -8,5 +8,10 @@ export function LoginPage() {
   const from = (location.state as { from?: { pathname: string; search: string } } | null)?.from;
   const redirectTo = from ? `${from.pathname}${from.search}` : PATHS.ADMIN_SHIFTS;
 
-  return <LoginForm onLoginSuccess={() => navigate(redirectTo, { replace: true })} />;
+  return (
+    <div className="w-full max-w-lg">
+      <h1 className="text-2xl font-semibold text-center text-gray-800 mb-6">Shiftyにログイン</h1>
+      <LoginForm onLoginSuccess={() => navigate(redirectTo, { replace: true })} />
+    </div>
+  );
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,17 +1,25 @@
-import { useNavigate, useLocation } from 'react-router-dom';
-import { LoginForm } from '../features/auth/components/LoginForm';
-import { PATHS } from '../routes/paths';
+import { useNavigate, useLocation } from "react-router-dom";
+import { LoginForm } from "../features/auth/components/LoginForm";
+import { PATHS } from "../routes/paths";
 
 export function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const from = (location.state as { from?: { pathname: string; search: string } } | null)?.from;
-  const redirectTo = from ? `${from.pathname}${from.search}` : PATHS.ADMIN_SHIFTS;
+  const from = (
+    location.state as { from?: { pathname: string; search: string } } | null
+  )?.from;
+  const redirectTo = from
+    ? `${from.pathname}${from.search}`
+    : PATHS.ADMIN_SHIFTS;
 
   return (
     <div className="w-full max-w-lg">
-      <h1 className="text-2xl font-semibold text-center text-gray-800 mb-6">Shiftyにログイン</h1>
-      <LoginForm onLoginSuccess={() => navigate(redirectTo, { replace: true })} />
+      <h1 className="text-3xl font-bold text-center text-gray-800 mb-8">
+        Shifty
+      </h1>
+      <LoginForm
+        onLoginSuccess={() => navigate(redirectTo, { replace: true })}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 概要

ポートフォリオとしての訴求力が不十分だったログインページのデザインを全面刷新しました。

## 変更内容

- **AuthLayout にフッターを追加** — コピーライト・利用規約・プライバシーポリシーを配置し、ページ構造を整備
- **LoginForm のデザイン改善** — カードサイズ・余白・フォントサイズを調整。メールアドレス省略チェックボックスを追加
- **カラーパレット・背景の刷新** — 背景をグラデーションからベタ塗りの白に変更し、全体をクリーンな白ベースに統一
- **CSS グローバルリセットのバグ修正** — `@layer` 外に書かれていた見出しリセットが Tailwind のマージンユーティリティを上書きしていた問題を修正
- **ボタンホバーのバグ修正** — `<button>` 要素でホバー時の色変化が効いていなかった問題を修正

## 今回スコープ外

- 利用規約・プライバシーポリシーのページ実装
- パスワードリセット・管理画面のデザイン改善

## 動作確認

- [x] `/login` でログインフォームが正常に表示される
- [x] メールアドレス・パスワードを入力してログインできる
- [x] 「次回からメールアドレスの入力を省略」チェックを ON にしてログイン後、再度 `/login` を開くとメールが自動入力される
- [x] チェックを OFF にしてログインすると保存済みメールが削除される
- [x] ボタンにホバーすると色が変化し、ポインターカーソルが表示される
- [x] フッターにコピーライト・利用規約・プライバシーポリシーが表示される