### PR TITLE
17.2 シフトブロック表示コンポーネント実装

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,8 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+    },
   },
 ])

--- a/src/features/shift/components/ShiftBlock.tsx
+++ b/src/features/shift/components/ShiftBlock.tsx
@@ -1,0 +1,16 @@
+import type { Shift } from '../types'
+import { formatShiftTime } from '../utils/formatShiftTime'
+
+interface ShiftBlockProps {
+  shift: Shift
+}
+
+export function ShiftBlock({ shift }: ShiftBlockProps) {
+  const timeLabel = formatShiftTime(shift.startTime, shift.endTime)
+
+  return (
+    <div className="w-full h-12 rounded-md bg-gray-200 flex items-center justify-center px-1.5 py-1">
+      <span className="text-xs whitespace-nowrap">{timeLabel}</span>
+    </div>
+  )
+}

--- a/src/features/shift/components/ShiftBlock.tsx
+++ b/src/features/shift/components/ShiftBlock.tsx
@@ -9,7 +9,7 @@ export function ShiftBlock({ shift }: ShiftBlockProps) {
   const timeLabel = formatShiftTime(shift.startTime, shift.endTime)
 
   return (
-    <div className="w-full h-12 rounded-md bg-gray-200 flex items-center justify-center px-1.5 py-1">
+    <div className="w-full h-full rounded-md bg-gray-200 flex items-center justify-center px-1.5">
       <span className="text-xs whitespace-nowrap">{timeLabel}</span>
     </div>
   )

--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -11,7 +11,6 @@ interface ShiftCellProps {
   isClosed?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function ShiftCell({
   staffId: _staffId,
   date: _date,

--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -1,12 +1,12 @@
 import { cn } from "@/lib/utils";
 import type { Shift } from "../types";
+import { ShiftBlock } from "./ShiftBlock";
 
 interface ShiftCellProps {
   // TODO: API接続タスク（Phase1）でシフト登録モーダルを開く際に使用
   staffId: number;
   // TODO: API接続タスク（Phase1）でシフト登録モーダルを開く際に使用
   date: Date;
-  // TODO: シフトデータ表示タスク（Phase1）でセル内に開始・終了時刻を描画する際に使用
   shift?: Shift;
   isClosed?: boolean;
 }
@@ -15,7 +15,7 @@ interface ShiftCellProps {
 export function ShiftCell({
   staffId: _staffId,
   date: _date,
-  shift: _shift,
+  shift,
   isClosed = false,
 }: ShiftCellProps) {
   return (
@@ -24,11 +24,13 @@ export function ShiftCell({
       type="button"
       disabled={isClosed}
       className={cn(
-        "h-16 w-full border-r border-gray-200",
+        "h-16 w-full border-r border-gray-200 p-0.5",
         isClosed
           ? "bg-gray-100 cursor-not-allowed"
           : "hover:bg-gray-100 cursor-pointer",
       )}
-    />
+    >
+      {shift && <ShiftBlock shift={shift} />}
+    </button>
   );
 }

--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -1,27 +1,34 @@
-import { cn } from '@/lib/utils'
-import type { ShiftData } from '../types'
+import { cn } from "@/lib/utils";
+import type { Shift } from "../types";
 
 interface ShiftCellProps {
   // TODO: API接続タスク（Phase1）でシフト登録モーダルを開く際に使用
-  staffId: number
+  staffId: number;
   // TODO: API接続タスク（Phase1）でシフト登録モーダルを開く際に使用
-  date: Date
+  date: Date;
   // TODO: シフトデータ表示タスク（Phase1）でセル内に開始・終了時刻を描画する際に使用
-  shift?: ShiftData
-  isClosed?: boolean
+  shift?: Shift;
+  isClosed?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function ShiftCell({ staffId: _staffId, date: _date, shift: _shift, isClosed = false }: ShiftCellProps) {
+export function ShiftCell({
+  staffId: _staffId,
+  date: _date,
+  shift: _shift,
+  isClosed = false,
+}: ShiftCellProps) {
   return (
     // TODO: タスク 18.1.1 で onClick にシフト登録モーダルを開くハンドラを渡す
     <button
       type="button"
       disabled={isClosed}
       className={cn(
-        'h-16 w-full border-r border-gray-200',
-        isClosed ? 'bg-gray-100 cursor-not-allowed' : 'hover:bg-gray-100 cursor-pointer',
+        "h-16 w-full border-r border-gray-200",
+        isClosed
+          ? "bg-gray-100 cursor-not-allowed"
+          : "hover:bg-gray-100 cursor-pointer",
       )}
     />
-  )
+  );
 }

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -1,35 +1,48 @@
-import { cn } from '@/lib/utils'
-import type { DateCell, DayOfWeek, Shift, Staff } from '../types'
-import { ShiftCell } from './ShiftCell'
+import { cn } from "@/lib/utils";
+import type { DateCell, DayOfWeek, Shift, Staff } from "../types";
+import { ShiftCell } from "./ShiftCell";
 
 // TODO: 17.3 完了後に削除する
 const DUMMY_SHIFT: Shift = {
   id: 1,
   staffId: 1,
-  date: '2026-05-01',
-  startTime: '09:00',
-  endTime: '18:00',
-  state: 'draft',
-}
+  date: "2026-05-01",
+  startTime: "09:00",
+  endTime: "18:00",
+  state: "draft",
+};
 
 interface StaffRowProps {
-  member: Staff
-  dates: DateCell[]
-  gridTemplateColumns: string
-  isEven: boolean
-  closedDays?: DayOfWeek[]
+  member: Staff;
+  dates: DateCell[];
+  gridTemplateColumns: string;
+  isEven: boolean;
+  closedDays?: DayOfWeek[];
 }
 
-export function StaffRow({ member, dates, gridTemplateColumns, isEven, closedDays = [] }: StaffRowProps) {
+export function StaffRow({
+  member,
+  dates,
+  gridTemplateColumns,
+  isEven,
+  closedDays = [],
+}: StaffRowProps) {
   return (
     <div
-      className={cn('grid border-b border-gray-200', isEven ? 'bg-white' : 'bg-gray-50')}
+      className={cn(
+        "grid border-b border-gray-200",
+        isEven ? "bg-white" : "bg-gray-50",
+      )}
       style={{ gridTemplateColumns }}
     >
       <div className="h-16 px-3 border-r-2 border-gray-300 flex flex-col justify-center gap-0.5 min-w-0">
-        <span className="text-xs font-medium text-gray-900 truncate">{member.name}</span>
+        <span className="text-xs font-medium text-gray-900 truncate">
+          {member.name}
+        </span>
         {member.position && (
-          <span className="text-[10px] text-gray-500 truncate">{member.position}</span>
+          <span className="text-[10px] text-gray-500 truncate">
+            {member.position}
+          </span>
         )}
       </div>
       {dates.map((cell, index) => (
@@ -43,5 +56,5 @@ export function StaffRow({ member, dates, gridTemplateColumns, isEven, closedDay
         />
       ))}
     </div>
-  )
+  );
 }

--- a/src/features/shift/components/StaffRow.tsx
+++ b/src/features/shift/components/StaffRow.tsx
@@ -1,6 +1,16 @@
 import { cn } from '@/lib/utils'
-import type { DateCell, DayOfWeek, Staff } from '../types'
+import type { DateCell, DayOfWeek, Shift, Staff } from '../types'
 import { ShiftCell } from './ShiftCell'
+
+// TODO: 17.3 完了後に削除する
+const DUMMY_SHIFT: Shift = {
+  id: 1,
+  staffId: 1,
+  date: '2026-05-01',
+  startTime: '09:00',
+  endTime: '18:00',
+  state: 'draft',
+}
 
 interface StaffRowProps {
   member: Staff
@@ -22,11 +32,13 @@ export function StaffRow({ member, dates, gridTemplateColumns, isEven, closedDay
           <span className="text-[10px] text-gray-500 truncate">{member.position}</span>
         )}
       </div>
-      {dates.map((cell) => (
+      {dates.map((cell, index) => (
         <ShiftCell
           key={cell.date.toISOString()}
           staffId={member.id}
           date={cell.date}
+          // TODO: 17.3 完了後に実データへ切り替える
+          shift={index === 0 && member.id === 1 ? DUMMY_SHIFT : undefined}
           isClosed={closedDays.includes(cell.dayOfWeek)}
         />
       ))}

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -1,4 +1,4 @@
-export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6
+export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface ShiftPeriod {
   from: Date;
@@ -16,10 +16,14 @@ export interface Staff {
   position?: string;
 }
 
-export interface ShiftData {
+export type ShiftState = "draft" | "confirmed";
+
+export interface Shift {
   id: number;
   staffId: number;
   date: string;
   startTime: string;
   endTime: string;
+  state: ShiftState;
+  positionId?: number;
 }

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -25,5 +25,6 @@ export interface Shift {
   startTime: string;
   endTime: string;
   state: ShiftState;
+  // 17.6.4 でポジション別カラー体系（hall/kitchen/register/other）を実装する際に参照する
   positionId?: number;
 }


### PR DESCRIPTION
## 概要

シフトグリッド各セル内に表示するシフトブロックコンポーネントをダミーデータで実装し、勤務時間を表示できるようにしました。ここで仮定義した `Shift` 型が、後続の 17.3（グリッド配置）・17.1（API）・17.4（フック）の設計基準になります。

## 変更内容

1. **APIレスポンスに合わせて `Shift` 型・`ShiftState` 型を作成**
   `features/shift/types/index.ts` に `ShiftState`（`'draft' | 'confirmed'`）と `Shift` インターフェースを追加し、後続タスクの設計基準として不十分だった `ShiftData` を置き換えました。

2. **勤務時間を表示するカードコンポーネント `ShiftBlock` を作成**
   `features/shift/components/ShiftBlock.tsx` を作成し、`Shift` オブジェクトを受け取って `formatShiftTime` で時刻テキストを生成・表示します。背景色は `bg-gray-200`（プレースホルダー）で、本スタイルは 17.6 で実装します。

3. **シフトセルにべた書きせず `ShiftBlock` コンポーネントを使用**
   `ShiftCell` はセルの枠とシフトがあるかどうかの分岐を担い、シフトデータの表示は `ShiftBlock` に委譲することで責務を分けました。

4. **ダミーデータで表示確認**
   `StaffRow` の `index === 0 && member.id === 1` のセルにのみ `DUMMY_SHIFT`（`09:00〜18:00 / draft`）を渡し、時刻テキストありセルと空セルの両パターンをブラウザで確認できる状態にしました。

## 今回スコープ外

- ポジション名の表示（セルは時刻のみ表示する方針のためスコープ削除）
- `shift_state` による背景色・ボーダー（17.6 で統合）
- `confirmed` シフトの編集不可スタイル（17.6 で統合）
- ダミーデータの実データへの切り替え（17.3 完了後に実施）

## 動作確認

- [x] `localhost:5173` のシフト表でスタッフ行の先頭セルにグレーカード（`09:00〜18:00`）が表示される
- [x] 残りのセルが空セルのまま表示される