### PR TITLE
17.4 シフト取得用カスタムフック実装（useShifts 等）

### DIFF
--- a/src/features/shift/api/__tests__/shifts.test.ts
+++ b/src/features/shift/api/__tests__/shifts.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchShifts } from '../shifts';
+
+vi.mock('../../../../shared/api/client', () => ({
+  get: vi.fn(),
+}));
+
+import { get } from '../../../../shared/api/client';
+
+const mockGet = vi.mocked(get);
+
+const makeSuccessResponse = (data: unknown) =>
+  new Response(
+    JSON.stringify({ status: 'success', data, message: null, errors: null }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+
+describe('fetchShifts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('APIレスポンスの snake_case フィールドが camelCase に変換され null が undefined になる', async () => {
+    mockGet.mockResolvedValue(
+      makeSuccessResponse([
+        {
+          id: 1,
+          staff_id: 2,
+          start_at: '2026-06-01T09:00:00+09:00',
+          end_at: '2026-06-01T18:00:00+09:00',
+          shift_state: 'draft',
+          position_id: null,
+          memo: null,
+        },
+      ]),
+    );
+
+    const result = await fetchShifts('2026-06-01', '2026-06-15');
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        staffId: 2,
+        startAt: '2026-06-01T09:00:00+09:00',
+        endAt: '2026-06-01T18:00:00+09:00',
+        state: 'draft',
+        positionId: undefined,
+        memo: undefined,
+      },
+    ]);
+  });
+
+  it('position_id に値があるとき positionId にその値が入る', async () => {
+    mockGet.mockResolvedValue(
+      makeSuccessResponse([
+        {
+          id: 1,
+          staff_id: 1,
+          start_at: '2026-06-01T09:00:00+09:00',
+          end_at: '2026-06-01T18:00:00+09:00',
+          shift_state: 'confirmed',
+          position_id: 3,
+          memo: null,
+        },
+      ]),
+    );
+
+    const result = await fetchShifts('2026-06-01', '2026-06-15');
+
+    expect(result[0].positionId).toBe(3);
+  });
+});

--- a/src/features/shift/api/shifts.ts
+++ b/src/features/shift/api/shifts.ts
@@ -1,0 +1,20 @@
+import { get } from '../../../shared/api/client';
+import { fetchJson } from '../../../shared/api/error';
+import type { ApiShiftResponse, Shift } from '../types';
+
+const toShift = (raw: ApiShiftResponse): Shift => ({
+  id: raw.id,
+  staffId: raw.staff_id,
+  startAt: raw.start_at,
+  endAt: raw.end_at,
+  state: raw.shift_state,
+  positionId: raw.position_id ?? undefined,
+  memo: raw.memo ?? undefined,
+});
+
+export const fetchShifts = async (from: string, to: string): Promise<Shift[]> => {
+  const params = new URLSearchParams({ from, to });
+  const response = await get(`/api/v1/shifts?${params}`);
+  const body = await fetchJson<{ data: ApiShiftResponse[] }>(response, 'シフトの取得に失敗しました');
+  return body.data.map(toShift);
+};

--- a/src/features/shift/hooks/useShifts.ts
+++ b/src/features/shift/hooks/useShifts.ts
@@ -1,0 +1,25 @@
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import { fetchShifts } from '../api/shifts';
+import type { ShiftPeriod } from '../types';
+
+const ONE_MINUTE = 60 * 1000;
+
+export const shiftQueryKeys = {
+  list: (from: string, to: string) => ['shifts', { from, to }] as const,
+};
+
+export const shiftsQueryOptions = (from: string, to: string) =>
+  queryOptions({
+    queryKey: shiftQueryKeys.list(from, to),
+    queryFn: () => fetchShifts(from, to),
+    staleTime: ONE_MINUTE,
+    gcTime: 5 * ONE_MINUTE,
+  });
+
+export const useShifts = (period: ShiftP- ShiftPeriod の Date を YYYY-MM-DD 文字列に変換して queryKey に含めることで同じ期間のキャッシュを正しく同一キーと判定できるようにした
+eriod) => {
+  const from = format(period.from, 'yyyy-MM-dd');
+  const to = format(period.to, 'yyyy-MM-dd');
+  return useQuery(shiftsQueryOptions(from, to));
+};

--- a/src/features/shift/hooks/useShifts.ts
+++ b/src/features/shift/hooks/useShifts.ts
@@ -17,8 +17,7 @@ export const shiftsQueryOptions = (from: string, to: string) =>
     gcTime: 5 * ONE_MINUTE,
   });
 
-export const useShifts = (period: ShiftP- ShiftPeriod の Date を YYYY-MM-DD 文字列に変換して queryKey に含めることで同じ期間のキャッシュを正しく同一キーと判定できるようにした
-eriod) => {
+export const useShifts = (period: ShiftPeriod) => {
   const from = format(period.from, 'yyyy-MM-dd');
   const to = format(period.to, 'yyyy-MM-dd');
   return useQuery(shiftsQueryOptions(from, to));

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -18,6 +18,17 @@ export interface Staff {
 
 export type ShiftState = "draft" | "confirmed";
 
+export interface ApiShiftResponse {
+  id: number;
+  staff_id: number;
+  start_at: string;
+  end_at: string;
+  shift_state: ShiftState;
+  position_id: number | null;
+  memo: string | null;
+  staff_profile?: { name: string };
+}
+
 export interface Shift {
   id: number;
   staffId: number;

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -26,6 +26,7 @@ export interface ApiShiftResponse {
   shift_state: ShiftState;
   position_id: number | null;
   memo: string | null;
+  // DUMMY_STAFF を API に差し替えるタスクで staffName のマッピングに使用する
   staff_profile?: { name: string };
 }
 

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -2,9 +2,10 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { PeriodLabel } from '../features/shift/components/PeriodLabel'
 import { ShiftGrid } from '../features/shift/components/ShiftGrid'
+import { useShifts } from '../features/shift/hooks/useShifts'
 import { usePeriodNavigation } from '../features/shift/hooks/usePeriodNavigation'
 import { generateDateRange } from '../features/shift/utils/generateDateRange'
-import type { DayOfWeek, Shift, Staff } from '../features/shift/types'
+import type { DayOfWeek, Staff } from '../features/shift/types'
 
 const DUMMY_STAFF: Staff[] = [
   { id: 1, name: '田中 太郎', position: '店長' },
@@ -14,22 +15,16 @@ const DUMMY_STAFF: Staff[] = [
   { id: 5, name: '渡辺 健太', position: 'キッチン' },
 ]
 
-// Phase1ダミー: 17.5 のAPI接続時に削除する
-const DUMMY_SHIFTS: Shift[] = [
-  { id: 1, staffId: 1, startAt: '2026-06-01T00:00:00Z', endAt: '2026-06-01T09:00:00Z', state: 'draft' },
-  { id: 2, staffId: 1, startAt: '2026-06-03T00:00:00Z', endAt: '2026-06-03T09:00:00Z', state: 'confirmed' },
-  { id: 3, staffId: 2, startAt: '2026-06-02T01:00:00Z', endAt: '2026-06-02T10:00:00Z', state: 'draft' },
-  { id: 4, staffId: 2, startAt: '2026-06-04T01:00:00Z', endAt: '2026-06-04T10:00:00Z', state: 'draft' },
-  { id: 5, staffId: 3, startAt: '2026-06-01T00:00:00Z', endAt: '2026-06-01T06:00:00Z', state: 'draft' },
-  { id: 6, staffId: 4, startAt: '2026-06-05T02:00:00Z', endAt: '2026-06-05T11:00:00Z', state: 'draft' },
-]
-
-// Phase1ダミー: 日曜（0）を定休日として設定（タスク17でAPIデータに差し替え）
+// Phase1ダミー: 日曜（0）を定休日として設定（設定API接続タスクで差し替え）
 const CLOSED_DAYS: DayOfWeek[] = [0]
 
 export function AdminShiftsPage() {
   const { period, goToPrev, goToNext } = usePeriodNavigation()
   const dates = generateDateRange(period)
+  const { data: shifts, isPending, isError } = useShifts(period)
+
+  if (isPending) return <p className="text-center text-sm text-gray-500">読み込み中...</p>
+  if (isError) return <p className="text-center text-sm text-red-500">シフトの取得に失敗しました</p>
 
   return (
     <div className="flex flex-col gap-4">
@@ -42,7 +37,7 @@ export function AdminShiftsPage() {
           <ChevronRight className="w-4 h-4" />
         </Button>
       </div>
-      <ShiftGrid dates={dates} members={DUMMY_STAFF} shifts={DUMMY_SHIFTS} closedDays={CLOSED_DAYS} />
+      <ShiftGrid dates={dates} members={DUMMY_STAFF} shifts={shifts ?? []} closedDays={CLOSED_DAYS} />
     </div>
   )
 }

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -23,9 +23,6 @@ export function AdminShiftsPage() {
   const dates = generateDateRange(period)
   const { data: shifts, isPending, isError } = useShifts(period)
 
-  if (isPending) return <p className="text-center text-sm text-gray-500">読み込み中...</p>
-  if (isError) return <p className="text-center text-sm text-red-500">シフトの取得に失敗しました</p>
-
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-center gap-3">
@@ -37,7 +34,11 @@ export function AdminShiftsPage() {
           <ChevronRight className="w-4 h-4" />
         </Button>
       </div>
-      <ShiftGrid dates={dates} members={DUMMY_STAFF} shifts={shifts ?? []} closedDays={CLOSED_DAYS} />
+      {isPending && <p className="text-center text-sm text-gray-500">読み込み中...</p>}
+      {isError && <p className="text-center text-sm text-red-500">シフトの取得に失敗しました</p>}
+      {!isPending && !isError && (
+        <ShiftGrid dates={dates} members={DUMMY_STAFF} shifts={shifts ?? []} closedDays={CLOSED_DAYS} />
+      )}
     </div>
   )
 }

--- a/src/pages/__tests__/AdminShiftsPage.test.tsx
+++ b/src/pages/__tests__/AdminShiftsPage.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { AdminShiftsPage } from '../AdminShiftsPage';
+import { createWrapper } from '@/test/utils';
+import type { Shift } from '@/features/shift/types';
+
+vi.mock('@/features/shift/hooks/useShifts', () => ({
+  useShifts: vi.fn(),
+}));
+
+import { useShifts } from '@/features/shift/hooks/useShifts';
+
+const mockUseShifts = vi.mocked(useShifts);
+
+describe('AdminShiftsPage', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.clearAllMocks();
+  });
+
+  it('isPending のとき「読み込み中...」が表示される', () => {
+    mockUseShifts.mockReturnValue(
+      { isPending: true, isError: false, data: undefined } as UseQueryResult<Shift[], Error>,
+    );
+
+    render(<AdminShiftsPage />, { wrapper: createWrapper(queryClient) });
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('isError のとき「シフトの取得に失敗しました」が表示される', () => {
+    mockUseShifts.mockReturnValue(
+      { isPending: false, isError: true, data: undefined } as UseQueryResult<Shift[], Error>,
+    );
+
+    render(<AdminShiftsPage />, { wrapper: createWrapper(queryClient) });
+
+    expect(screen.getByText('シフトの取得に失敗しました')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

シフトページのダミーデータを実 API に接続するため、React Query を使ったデータ取得フックを実装しました。

## 変更内容

1. **変換層の追加（ApiShiftResponse / fetchShifts）**

   バックエンドは snake_case（`staff_id`, `shift_state` など）を返すがフロントエンドは camelCase で統一しているため、`fetchShifts` 内に変換処理を集約しました。API の変更が他のコードに波及しないようにしています。

2. **useShifts フックの実装**

   コンポーネントから API 呼び出しの詳細を隠すためカスタムフックに切り出しました。期間（from/to）を queryKey に含めることで、期間変更時に自動で再フェッチされます。

3. **AdminShiftsPage への組み込み**

   ダミーシフトを削除し、useShifts で取得した実データをグリッドに渡しています。ローディング中・エラー時もナビゲーションを操作できるようにしました。

## 今回スコープ外

- スタッフ一覧・定休日の API 接続（別タスク）

## 動作確認

- [x] Network タブで shifts API リクエストが発行される
- [x] DB のシフトデータがグリッドに表示される
- [x] `vitest run` で全テスト PASS