### PR TITLE
17.6 ShiftCalendar Figmaデザイン刷新

### DIFF
--- a/src/features/shift/api/__tests__/shifts.test.ts
+++ b/src/features/shift/api/__tests__/shifts.test.ts
@@ -29,7 +29,7 @@ describe('fetchShifts', () => {
           start_at: '2026-06-01T09:00:00+09:00',
           end_at: '2026-06-01T18:00:00+09:00',
           shift_state: 'draft',
-          position_id: null,
+          position: null,
           memo: null,
         },
       ]),
@@ -44,13 +44,13 @@ describe('fetchShifts', () => {
         startAt: '2026-06-01T09:00:00+09:00',
         endAt: '2026-06-01T18:00:00+09:00',
         state: 'draft',
-        positionId: undefined,
+        positionName: undefined,
         memo: undefined,
       },
     ]);
   });
 
-  it('position_id に値があるとき positionId にその値が入る', async () => {
+  it('position.name があるとき positionName にその値が入る', async () => {
     mockGet.mockResolvedValue(
       makeSuccessResponse([
         {
@@ -59,7 +59,7 @@ describe('fetchShifts', () => {
           start_at: '2026-06-01T09:00:00+09:00',
           end_at: '2026-06-01T18:00:00+09:00',
           shift_state: 'confirmed',
-          position_id: 3,
+          position: { name: 'ホール' },
           memo: null,
         },
       ]),
@@ -67,6 +67,6 @@ describe('fetchShifts', () => {
 
     const result = await fetchShifts('2026-06-01', '2026-06-15');
 
-    expect(result[0].positionId).toBe(3);
+    expect(result[0].positionName).toBe('ホール');
   });
 });

--- a/src/features/shift/api/shifts.ts
+++ b/src/features/shift/api/shifts.ts
@@ -8,7 +8,7 @@ const toShift = (raw: ApiShiftResponse): Shift => ({
   startAt: raw.start_at,
   endAt: raw.end_at,
   state: raw.shift_state,
-  positionId: raw.position_id ?? undefined,
+  positionName: raw.position?.name ?? undefined,
   memo: raw.memo ?? undefined,
 });
 

--- a/src/features/shift/components/BalanceBar.tsx
+++ b/src/features/shift/components/BalanceBar.tsx
@@ -1,0 +1,26 @@
+type BalanceStatus = 'shortage' | 'just' | 'surplus'
+
+interface BalanceBarProps {
+  status: BalanceStatus
+  diff: number
+}
+
+const STATUS_COLORS: Record<BalanceStatus, string> = {
+  shortage: 'bg-red-500',
+  just: 'bg-green-500',
+  surplus: 'bg-blue-500',
+}
+
+function formatDiff(status: BalanceStatus, diff: number): string {
+  if (status === 'just') return 'OK'
+  if (status === 'shortage') return `▲${Math.abs(diff)}`
+  return `+${diff}`
+}
+
+export function BalanceBar({ status, diff }: BalanceBarProps) {
+  return (
+    <div className={`h-5 ${STATUS_COLORS[status]} flex items-center justify-center`}>
+      <span className="text-[10px] text-white">{formatDiff(status, diff)}</span>
+    </div>
+  )
+}

--- a/src/features/shift/components/BalanceBar.tsx
+++ b/src/features/shift/components/BalanceBar.tsx
@@ -1,4 +1,4 @@
-type BalanceStatus = 'shortage' | 'just' | 'surplus'
+import type { BalanceStatus } from '../types'
 
 interface BalanceBarProps {
   status: BalanceStatus

--- a/src/features/shift/components/ShiftBlock.tsx
+++ b/src/features/shift/components/ShiftBlock.tsx
@@ -7,14 +7,14 @@ interface ShiftBlockProps {
 }
 
 export function ShiftBlock({ shift }: ShiftBlockProps) {
-  const timeLabel = `${format(parseISO(shift.startAt), "HH:mm")}〜${format(parseISO(shift.endAt), "HH:mm")}`;
+  const timeLabel = `${format(parseISO(shift.startAt), "HH:mm")} - ${format(parseISO(shift.endAt), "HH:mm")}`;
   const colorClasses = getShiftColorClasses(shift.state, shift.positionName);
 
   return (
     <div
-      className={`w-full h-full rounded-md flex items-center justify-center px-1.5 ${colorClasses}`}
+      className={`w-full h-13 rounded-md shadow-sm flex items-center justify-center px-1.5 ${colorClasses}`}
     >
-      <span className="text-xs whitespace-nowrap">{timeLabel}</span>
+      <span className="text-[11px] whitespace-nowrap">{timeLabel}</span>
     </div>
   );
 }

--- a/src/features/shift/components/ShiftBlock.tsx
+++ b/src/features/shift/components/ShiftBlock.tsx
@@ -1,16 +1,20 @@
-import { format, parseISO } from 'date-fns'
-import type { Shift } from '../types'
+import { format, parseISO } from "date-fns";
+import type { Shift } from "../types";
+import { getShiftBlockClasses } from "../utils/getShiftBlockClasses";
 
 interface ShiftBlockProps {
-  shift: Shift
+  shift: Shift;
 }
 
 export function ShiftBlock({ shift }: ShiftBlockProps) {
-  const timeLabel = `${format(parseISO(shift.startAt), 'HH:mm')}〜${format(parseISO(shift.endAt), 'HH:mm')}`
+  const timeLabel = `${format(parseISO(shift.startAt), "HH:mm")}〜${format(parseISO(shift.endAt), "HH:mm")}`;
+  const colorClasses = getShiftBlockClasses(shift.state);
 
   return (
-    <div className="w-full h-full rounded-md bg-gray-200 flex items-center justify-center px-1.5">
+    <div
+      className={`w-full h-full rounded-md flex items-center justify-center px-1.5 ${colorClasses}`}
+    >
       <span className="text-xs whitespace-nowrap">{timeLabel}</span>
     </div>
-  )
+  );
 }

--- a/src/features/shift/components/ShiftBlock.tsx
+++ b/src/features/shift/components/ShiftBlock.tsx
@@ -1,6 +1,6 @@
 import { format, parseISO } from "date-fns";
 import type { Shift } from "../types";
-import { getShiftBlockClasses } from "../utils/getShiftBlockClasses";
+import { getShiftColorClasses } from "../utils/getShiftColorClasses";
 
 interface ShiftBlockProps {
   shift: Shift;
@@ -8,7 +8,7 @@ interface ShiftBlockProps {
 
 export function ShiftBlock({ shift }: ShiftBlockProps) {
   const timeLabel = `${format(parseISO(shift.startAt), "HH:mm")}〜${format(parseISO(shift.endAt), "HH:mm")}`;
-  const colorClasses = getShiftBlockClasses(shift.state);
+  const colorClasses = getShiftColorClasses(shift.state, shift.positionName);
 
   return (
     <div

--- a/src/features/shift/components/ShiftCell.tsx
+++ b/src/features/shift/components/ShiftCell.tsx
@@ -26,7 +26,7 @@ export function ShiftCell({
         "h-16 w-full border-r border-gray-200 p-0.5",
         isClosed
           ? "bg-gray-100 cursor-not-allowed"
-          : "hover:bg-gray-100 cursor-pointer",
+          : "hover:bg-gray-100 cursor-pointer transition-colors",
       )}
     >
       {shift && <ShiftBlock shift={shift} />}

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -26,7 +26,9 @@ export function ShiftGrid({ dates, members, shifts, closedDays = [] }: ShiftGrid
       <div className="w-max min-w-full border-t border-l border-gray-200">
         <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} closedDays={closedDays} />
         <div className="grid" style={{ gridTemplateColumns }}>
-          <div className="border-r-2 border-b border-gray-300" />
+          <div className="border-r-2 border-b border-gray-300 flex items-center px-3">
+            <span className="text-xs text-gray-500">必要人数</span>
+          </div>
           {dates.map((cell, index) => (
             <div key={cell.date.toISOString()} className="border-r border-b border-gray-200">
               <BalanceBar

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -1,10 +1,14 @@
 import type { DateCell, DayOfWeek, Shift, Staff } from '../types'
 import { groupShiftsByStaffAndDate } from '../utils/groupShiftsByStaffAndDate'
+import { BalanceBar } from './BalanceBar'
 import { DateHeaderRow } from './DateHeaderRow'
 import { StaffRow } from './StaffRow'
 
 const STAFF_COL_WIDTH = '120px'
 const DATE_COL_MIN_WIDTH = '80px'
+
+const DUMMY_BALANCE_STATUSES = ['shortage', 'just', 'surplus'] as const
+const DUMMY_BALANCE_DIFFS = [-2, 0, 1] as const
 
 interface ShiftGridProps {
   dates: DateCell[]
@@ -21,6 +25,17 @@ export function ShiftGrid({ dates, members, shifts, closedDays = [] }: ShiftGrid
     <div className="overflow-x-auto bg-gray-50">
       <div className="w-max min-w-full border-t border-l border-gray-200">
         <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} closedDays={closedDays} />
+        <div className="grid" style={{ gridTemplateColumns }}>
+          <div className="border-r-2 border-b border-gray-300" />
+          {dates.map((cell, index) => (
+            <div key={cell.date.toISOString()} className="border-r border-b border-gray-200">
+              <BalanceBar
+                status={DUMMY_BALANCE_STATUSES[index % DUMMY_BALANCE_STATUSES.length]}
+                diff={DUMMY_BALANCE_DIFFS[index % DUMMY_BALANCE_DIFFS.length]}
+              />
+            </div>
+          ))}
+        </div>
         {members.map((member, index) => (
           <StaffRow
             key={member.id}

--- a/src/features/shift/components/__tests__/BalanceBar.test.tsx
+++ b/src/features/shift/components/__tests__/BalanceBar.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { BalanceBar } from '../BalanceBar'
+
+describe('BalanceBar', () => {
+  it('shortage のとき bg-red-500 クラスと ▲N テキストを表示する', () => {
+    const { container } = render(<BalanceBar status="shortage" diff={-2} />)
+    expect(screen.getByText('▲2')).toBeInTheDocument()
+    expect(container.firstChild).toHaveClass('bg-red-500')
+  })
+
+  it('just のとき bg-green-500 クラスと OK テキストを表示する', () => {
+    const { container } = render(<BalanceBar status="just" diff={0} />)
+    expect(screen.getByText('OK')).toBeInTheDocument()
+    expect(container.firstChild).toHaveClass('bg-green-500')
+  })
+
+  it('surplus のとき bg-blue-500 クラスと +N テキストを表示する', () => {
+    const { container } = render(<BalanceBar status="surplus" diff={1} />)
+    expect(screen.getByText('+1')).toBeInTheDocument()
+    expect(container.firstChild).toHaveClass('bg-blue-500')
+  })
+})

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -24,7 +24,7 @@ export interface ApiShiftResponse {
   start_at: string;
   end_at: string;
   shift_state: ShiftState;
-  position_id: number | null;
+  position: { name: string } | null;
   memo: string | null;
   // DUMMY_STAFF を API に差し替えるタスクで staffName のマッピングに使用する
   staff_profile?: { name: string };
@@ -36,7 +36,6 @@ export interface Shift {
   startAt: string;
   endAt: string;
   state: ShiftState;
-  // 17.6.4 でポジション別カラー体系（hall/kitchen/register/other）を実装する際に参照する
-  positionId?: number;
+  positionName?: string;
   memo?: string;
 }

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -18,6 +18,8 @@ export interface Staff {
 
 export type ShiftState = "draft" | "confirmed";
 
+export type BalanceStatus = "shortage" | "just" | "surplus";
+
 export interface ApiShiftResponse {
   id: number;
   staff_id: number;

--- a/src/features/shift/utils/__tests__/getShiftColorClasses.test.ts
+++ b/src/features/shift/utils/__tests__/getShiftColorClasses.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { getShiftColorClasses } from '../getShiftColorClasses'
+
+describe('getShiftColorClasses', () => {
+  it('ホール + confirmed で bg-blue-500 text-white を返す', () => {
+    const result = getShiftColorClasses('confirmed', 'ホール')
+    expect(result).toContain('bg-blue-500')
+    expect(result).toContain('text-white')
+  })
+
+  it('ホール + draft で bg-blue-200 border-blue-400 を返す', () => {
+    const result = getShiftColorClasses('draft', 'ホール')
+    expect(result).toContain('bg-blue-200')
+    expect(result).toContain('text-gray-800')
+    expect(result).toContain('border')
+    expect(result).toContain('border-blue-400')
+  })
+
+  it('positionName が undefined のとき other（slate）系クラスを返す', () => {
+    const result = getShiftColorClasses('confirmed', undefined)
+    expect(result).toContain('bg-slate-400')
+    expect(result).toContain('text-white')
+  })
+
+  it('未知のポジション名のとき other（slate）系クラスを返す', () => {
+    const result = getShiftColorClasses('confirmed', '不明')
+    expect(result).toContain('bg-slate-400')
+    expect(result).toContain('text-white')
+  })
+})

--- a/src/features/shift/utils/getShiftBlockClasses.ts
+++ b/src/features/shift/utils/getShiftBlockClasses.ts
@@ -1,8 +1,0 @@
-import type { ShiftState } from '../types'
-
-export function getShiftBlockClasses(state: ShiftState): string {
-  if (state === 'confirmed') {
-    return 'bg-blue-500 text-white'
-  }
-  return 'bg-blue-200 text-gray-800 border border-blue-400'
-}

--- a/src/features/shift/utils/getShiftBlockClasses.ts
+++ b/src/features/shift/utils/getShiftBlockClasses.ts
@@ -1,0 +1,8 @@
+import type { ShiftState } from '../types'
+
+export function getShiftBlockClasses(state: ShiftState): string {
+  if (state === 'confirmed') {
+    return 'bg-blue-500 text-white'
+  }
+  return 'bg-blue-200 text-gray-800 border border-blue-400'
+}

--- a/src/features/shift/utils/getShiftColorClasses.ts
+++ b/src/features/shift/utils/getShiftColorClasses.ts
@@ -1,0 +1,28 @@
+import type { ShiftState } from '../types'
+
+type PositionColorSet = {
+  confirmed: string
+  draft: string
+}
+
+const POSITION_COLORS: Partial<Record<string, PositionColorSet>> = {
+  ホール: {
+    confirmed: 'bg-blue-500 text-white',
+    draft: 'bg-blue-200 text-gray-800 border border-blue-400',
+  },
+  キッチン: {
+    confirmed: 'bg-green-500 text-white',
+    draft: 'bg-green-200 text-gray-800 border border-green-400',
+  },
+}
+
+const OTHER_COLORS: PositionColorSet = {
+  confirmed: 'bg-slate-400 text-white',
+  draft: 'bg-slate-200 text-gray-800 border border-slate-400',
+}
+
+export function getShiftColorClasses(state: ShiftState, positionName?: string): string {
+  const colorSet: PositionColorSet =
+    (positionName !== undefined ? POSITION_COLORS[positionName] : undefined) ?? OTHER_COLORS
+  return colorSet[state]
+}


### PR DESCRIPTION
## 概要

ShiftCalendar コンポーネント群のデザイン性・視認性を向上しました。

## 変更内容

1. **ShiftBlock 状態別カラー（17.6.3）**
   確認済みシフトと下書きシフトを色で区別できるように実装。

   - confirmed は不透明色、draft は半透明 + ボーダーで視覚的に区別

2. **ポジション別カラー体系（17.6.4）**
   ポジションごとにシフトを色分けし、勤務構成の視認性を向上。

   色のキーには `position_id`（数値）ではなく `positionName`（文字列）を採用。本番環境では ID が保証されない（UI/API 経由での登録によりシーダーとの採番が一致しない）ため、業務的に安定している名前に統一した。

   （実装詳細は各コミット参照）

3. **BalanceBar コンポーネント（17.6.5）**
   日付列ごとの人員過不足（shortage / just / surplus）を色とラベルで表示するコンポーネントを新規作成し、ShiftGrid のヘッダー直下に配置。

   - Phase1 制約: 必要人数行の集計ロジックは未実装のため、ダミーデータで位置を確保

4. **16.5 スタイリング調整（17.6.6）**
   後回しにしていた基本スタイリング調整を完結。

   - ShiftBlock をセル内でカードとして浮かせた見た目に統一

## 今回スコープ外

- BalanceBar の実データ連携（必要人数設定・充足計算ロジック）
- 空セルの「+」インジケーター（タスク 18.1.1 でシフト登録モーダルと同時に実装）

## 動作確認

- [x] ShiftGrid でホール（青）・キッチン（緑）のポジション別カラーが表示される
- [x] confirmed（濃色）/ draft（薄色 + ボーダー）が視覚的に区別できる
- [x] BalanceBar がヘッダー直下に shortage（赤）/ just（緑）/ surplus（青）で表示される
- [x] 「必要人数」ラベルがスタッフ列に表示される