### PR TITLE
feat: [18.3] 時間入力 UI（開始・終了時刻）実装

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,199 @@
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -76,7 +76,7 @@ function SelectContent({
         align={align}
         alignOffset={alignOffset}
         alignItemWithTrigger={alignItemWithTrigger}
-        className="isolate z-50"
+        className="isolate z-100"
       >
         <SelectPrimitive.Popup
           data-slot="select-content"

--- a/src/features/shift/api/shifts.ts
+++ b/src/features/shift/api/shifts.ts
@@ -7,7 +7,10 @@ const toShift = (raw: ApiShiftResponse): Shift => ({
   staffId: raw.staff_id,
   startAt: raw.start_at,
   endAt: raw.end_at,
+  breakStartAt: raw.break_start_at ?? undefined,
+  breakEndAt: raw.break_end_at ?? undefined,
   state: raw.shift_state,
+  positionId: raw.position?.id ?? undefined,
   positionName: raw.position?.name ?? undefined,
   memo: raw.memo ?? undefined,
 });

--- a/src/features/shift/components/ShiftEditForm.tsx
+++ b/src/features/shift/components/ShiftEditForm.tsx
@@ -19,12 +19,17 @@ import {
   type ShiftEditFormValues,
 } from '../schemas/shiftEditSchema'
 
+const START_HOUR = 9
+const END_HOUR = 22
+const MINUTE_INTERVAL = 15
+const MINUTES_PER_HOUR = 60
+
 const TIME_OPTIONS = generateTimeOptions()
 
 function generateTimeOptions(): string[] {
   const times: string[] = []
-  for (let hour = 9; hour <= 22; hour++) {
-    for (let minute = 0; minute < 60; minute += 15) {
+  for (let hour = START_HOUR; hour <= END_HOUR; hour++) {
+    for (let minute = 0; minute < MINUTES_PER_HOUR; minute += MINUTE_INTERVAL) {
       times.push(
         `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`,
       )

--- a/src/features/shift/components/ShiftEditForm.tsx
+++ b/src/features/shift/components/ShiftEditForm.tsx
@@ -2,7 +2,15 @@ import { Combobox } from '@base-ui/react/combobox'
 import { CheckIcon } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import type { Shift } from '../types'
+import { usePositions } from '../hooks/usePositions'
 
 const TIME_OPTIONS = generateTimeOptions()
 
@@ -69,8 +77,26 @@ interface ShiftEditFormProps {
 }
 
 export function ShiftEditForm({ shift, isPending = false }: ShiftEditFormProps) {
+  const positions = usePositions()
+
   return (
     <div className="space-y-6 py-4">
+      <div className="space-y-2">
+        <Label>ポジション</Label>
+        <Select defaultValue={shift?.positionId?.toString()} disabled={isPending}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="選択してください" />
+          </SelectTrigger>
+          <SelectContent>
+            {positions.map((position) => (
+              <SelectItem key={position.id} value={position.id.toString()} label={position.name}>
+                {position.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
           <Label>出勤時間</Label>

--- a/src/features/shift/components/ShiftEditForm.tsx
+++ b/src/features/shift/components/ShiftEditForm.tsx
@@ -13,7 +13,11 @@ import {
 } from '@/components/ui/select'
 import type { Shift } from '../types'
 import { usePositions } from '../hooks/usePositions'
-import { shiftEditSchema, type ShiftEditFormValues } from '../schemas/shiftEditSchema'
+import {
+  shiftEditSchema,
+  type ShiftEditFormInput,
+  type ShiftEditFormValues,
+} from '../schemas/shiftEditSchema'
 
 const TIME_OPTIONS = generateTimeOptions()
 
@@ -89,14 +93,14 @@ export function ShiftEditForm({ shift, isPending = false, onSubmit }: ShiftEditF
   const positions = usePositions()
   const positionItems = positions.map((p) => ({ value: p.id.toString(), label: p.name }))
 
-  const { control, register, handleSubmit, formState: { errors } } = useForm<ShiftEditFormValues>({
+  const { control, register, handleSubmit, formState: { errors } } = useForm<ShiftEditFormInput, unknown, ShiftEditFormValues>({
     resolver: zodResolver(shiftEditSchema),
     defaultValues: {
       positionId: shift?.positionId?.toString() ?? '',
       startTime: shift?.startAt?.slice(11, 16) ?? '09:00',
       endTime: shift?.endAt?.slice(11, 16) ?? '18:00',
-      breakStartTime: shift?.breakStartAt?.slice(11, 16) ?? '12:00',
-      breakEndTime: shift?.breakEndAt?.slice(11, 16) ?? '13:00',
+      breakStartTime: shift?.breakStartAt?.slice(11, 16) ?? '',
+      breakEndTime: shift?.breakEndAt?.slice(11, 16) ?? '',
       memo: shift?.memo ?? '',
     },
   })

--- a/src/features/shift/components/ShiftEditForm.tsx
+++ b/src/features/shift/components/ShiftEditForm.tsx
@@ -113,7 +113,7 @@ export function ShiftEditForm({ shift, isPending = false, onSubmit }: ShiftEditF
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="選択してください" />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent alignItemWithTrigger={false}>
                 {positions.map((position) => (
                   <SelectItem key={position.id} value={position.id.toString()}>
                     {position.name}

--- a/src/features/shift/components/ShiftEditForm.tsx
+++ b/src/features/shift/components/ShiftEditForm.tsx
@@ -1,0 +1,109 @@
+import { Combobox } from '@base-ui/react/combobox'
+import { CheckIcon } from 'lucide-react'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import type { Shift } from '../types'
+
+const TIME_OPTIONS = generateTimeOptions()
+
+function generateTimeOptions(): string[] {
+  const times: string[] = []
+  for (let hour = 9; hour <= 22; hour++) {
+    for (let minute = 0; minute < 60; minute += 15) {
+      times.push(
+        `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`,
+      )
+    }
+  }
+  return times
+}
+
+interface TimeComboboxProps {
+  defaultValue: string
+  disabled?: boolean
+}
+
+function TimeCombobox({ defaultValue, disabled = false }: TimeComboboxProps) {
+  const filterFn = (item: string, query: string) => {
+    if (!query) return true
+    const normalizedItem = item.replace(':', '')
+    const normalizedQuery = query.replace(':', '')
+    return normalizedItem.startsWith(normalizedQuery)
+  }
+
+  return (
+    <Combobox.Root defaultValue={defaultValue} disabled={disabled} filter={filterFn} items={TIME_OPTIONS} autoHighlight>
+      <Combobox.Input
+        className="h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+        placeholder="00:00"
+      />
+      <Combobox.Portal>
+        <Combobox.Positioner sideOffset={4} className="z-50">
+          <Combobox.Popup className="max-h-60 overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+            <Combobox.List>
+              {(item: string) => (
+                <Combobox.Item
+                  value={item}
+                  className="relative flex w-full cursor-default items-center rounded-md py-1 pr-8 pl-2 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50"
+                >
+                  <span className="flex-1">{item}</span>
+                  <Combobox.ItemIndicator className="absolute right-2 flex size-4 items-center justify-center">
+                    <CheckIcon className="size-4" />
+                  </Combobox.ItemIndicator>
+                </Combobox.Item>
+              )}
+            </Combobox.List>
+            <Combobox.Empty className="px-2 py-4 text-center text-sm text-muted-foreground">
+              該当なし
+            </Combobox.Empty>
+          </Combobox.Popup>
+        </Combobox.Positioner>
+      </Combobox.Portal>
+    </Combobox.Root>
+  )
+}
+
+interface ShiftEditFormProps {
+  shift?: Shift
+  isPending?: boolean
+}
+
+export function ShiftEditForm({ shift, isPending = false }: ShiftEditFormProps) {
+  return (
+    <div className="space-y-6 py-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label>出勤時間</Label>
+          <TimeCombobox defaultValue={shift?.startAt?.slice(11, 16) ?? '09:00'} disabled={isPending} />
+        </div>
+
+        <div className="space-y-2">
+          <Label>退勤時間</Label>
+          <TimeCombobox defaultValue={shift?.endAt?.slice(11, 16) ?? '18:00'} disabled={isPending} />
+        </div>
+
+        <div className="space-y-2">
+          <Label>休憩開始</Label>
+          <TimeCombobox defaultValue={shift?.breakStartAt?.slice(11, 16) ?? '12:00'} disabled={isPending} />
+        </div>
+
+        <div className="space-y-2">
+          <Label>休憩終了</Label>
+          <TimeCombobox defaultValue={shift?.breakEndAt?.slice(11, 16) ?? '13:00'} disabled={isPending} />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="shift-memo">メモ</Label>
+        <Textarea
+          id="shift-memo"
+          defaultValue={shift?.memo ?? ''}
+          placeholder="メモを入力（任意）"
+          rows={4}
+          disabled={isPending}
+          className="resize-none"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/features/shift/components/ShiftEditForm.tsx
+++ b/src/features/shift/components/ShiftEditForm.tsx
@@ -123,9 +123,9 @@ export function ShiftEditForm({ shift, isPending = false, onSubmit }: ShiftEditF
                 <SelectValue placeholder="選択してください" />
               </SelectTrigger>
               <SelectContent alignItemWithTrigger={false}>
-                {positions.map((position) => (
-                  <SelectItem key={position.id} value={position.id.toString()}>
-                    {position.name}
+                {positionItems.map((item) => (
+                  <SelectItem key={item.value} value={item.value}>
+                    {item.label}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/features/shift/components/ShiftEditForm.tsx
+++ b/src/features/shift/components/ShiftEditForm.tsx
@@ -1,3 +1,5 @@
+import { useForm, Controller } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { Combobox } from '@base-ui/react/combobox'
 import { CheckIcon } from 'lucide-react'
 import { Label } from '@/components/ui/label'
@@ -11,6 +13,7 @@ import {
 } from '@/components/ui/select'
 import type { Shift } from '../types'
 import { usePositions } from '../hooks/usePositions'
+import { shiftEditSchema, type ShiftEditFormValues } from '../schemas/shiftEditSchema'
 
 const TIME_OPTIONS = generateTimeOptions()
 
@@ -27,11 +30,13 @@ function generateTimeOptions(): string[] {
 }
 
 interface TimeComboboxProps {
-  defaultValue: string
+  value: string
+  onChange: (value: string) => void
   disabled?: boolean
+  error?: string
 }
 
-function TimeCombobox({ defaultValue, disabled = false }: TimeComboboxProps) {
+function TimeCombobox({ value, onChange, disabled = false, error }: TimeComboboxProps) {
   const filterFn = (item: string, query: string) => {
     if (!query) return true
     const normalizedItem = item.replace(':', '')
@@ -40,96 +45,146 @@ function TimeCombobox({ defaultValue, disabled = false }: TimeComboboxProps) {
   }
 
   return (
-    <Combobox.Root defaultValue={defaultValue} disabled={disabled} filter={filterFn} items={TIME_OPTIONS} autoHighlight>
-      <Combobox.Input
-        className="h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
-        placeholder="00:00"
-      />
-      <Combobox.Portal>
-        <Combobox.Positioner sideOffset={4} className="z-50">
-          <Combobox.Popup className="max-h-60 overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
-            <Combobox.List>
-              {(item: string) => (
-                <Combobox.Item
-                  value={item}
-                  className="relative flex w-full cursor-default items-center rounded-md py-1 pr-8 pl-2 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50"
-                >
-                  <span className="flex-1">{item}</span>
-                  <Combobox.ItemIndicator className="absolute right-2 flex size-4 items-center justify-center">
-                    <CheckIcon className="size-4" />
-                  </Combobox.ItemIndicator>
-                </Combobox.Item>
-              )}
-            </Combobox.List>
-            <Combobox.Empty className="px-2 py-4 text-center text-sm text-muted-foreground">
-              該当なし
-            </Combobox.Empty>
-          </Combobox.Popup>
-        </Combobox.Positioner>
-      </Combobox.Portal>
-    </Combobox.Root>
+    <div>
+      <Combobox.Root value={value} onValueChange={(v) => { if (v !== null) onChange(v) }} disabled={disabled} filter={filterFn} items={TIME_OPTIONS} autoHighlight>
+        <Combobox.Input
+          className="h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder="00:00"
+        />
+        <Combobox.Portal>
+          <Combobox.Positioner sideOffset={4} className="z-50">
+            <Combobox.Popup className="max-h-60 overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95">
+              <Combobox.List>
+                {(item: string) => (
+                  <Combobox.Item
+                    value={item}
+                    className="relative flex w-full cursor-default items-center rounded-md py-1 pr-8 pl-2 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50"
+                  >
+                    <span className="flex-1">{item}</span>
+                    <Combobox.ItemIndicator className="absolute right-2 flex size-4 items-center justify-center">
+                      <CheckIcon className="size-4" />
+                    </Combobox.ItemIndicator>
+                  </Combobox.Item>
+                )}
+              </Combobox.List>
+              <Combobox.Empty className="px-2 py-4 text-center text-sm text-muted-foreground">
+                該当なし
+              </Combobox.Empty>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>
+      {error && <p className="text-sm text-red-500 mt-1">{error}</p>}
+    </div>
   )
 }
 
 interface ShiftEditFormProps {
   shift?: Shift
   isPending?: boolean
+  onSubmit: (values: ShiftEditFormValues) => void
 }
 
-export function ShiftEditForm({ shift, isPending = false }: ShiftEditFormProps) {
+export function ShiftEditForm({ shift, isPending = false, onSubmit }: ShiftEditFormProps) {
   const positions = usePositions()
+  const positionItems = positions.map((p) => ({ value: p.id.toString(), label: p.name }))
+
+  const { control, register, handleSubmit, formState: { errors } } = useForm<ShiftEditFormValues>({
+    resolver: zodResolver(shiftEditSchema),
+    defaultValues: {
+      positionId: shift?.positionId?.toString() ?? '',
+      startTime: shift?.startAt?.slice(11, 16) ?? '09:00',
+      endTime: shift?.endAt?.slice(11, 16) ?? '18:00',
+      breakStartTime: shift?.breakStartAt?.slice(11, 16) ?? '12:00',
+      breakEndTime: shift?.breakEndAt?.slice(11, 16) ?? '13:00',
+      memo: shift?.memo ?? '',
+    },
+  })
 
   return (
-    <div className="space-y-6 py-4">
+    <form id="shift-edit-form" onSubmit={handleSubmit(onSubmit)} className="space-y-6 py-4">
       <div className="space-y-2">
         <Label>ポジション</Label>
-        <Select defaultValue={shift?.positionId?.toString()} disabled={isPending}>
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="選択してください" />
-          </SelectTrigger>
-          <SelectContent>
-            {positions.map((position) => (
-              <SelectItem key={position.id} value={position.id.toString()} label={position.name}>
-                {position.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Controller
+          name="positionId"
+          control={control}
+          render={({ field }) => (
+            <Select value={field.value} onValueChange={field.onChange} disabled={isPending} items={positionItems}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="選択してください" />
+              </SelectTrigger>
+              <SelectContent>
+                {positions.map((position) => (
+                  <SelectItem key={position.id} value={position.id.toString()}>
+                    {position.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        />
+        {errors.positionId && <p className="text-sm text-red-500">{errors.positionId.message}</p>}
       </div>
 
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
           <Label>出勤時間</Label>
-          <TimeCombobox defaultValue={shift?.startAt?.slice(11, 16) ?? '09:00'} disabled={isPending} />
+          <Controller
+            name="startTime"
+            control={control}
+            render={({ field }) => (
+              <TimeCombobox value={field.value} onChange={field.onChange} disabled={isPending} error={errors.startTime?.message} />
+            )}
+          />
         </div>
 
         <div className="space-y-2">
           <Label>退勤時間</Label>
-          <TimeCombobox defaultValue={shift?.endAt?.slice(11, 16) ?? '18:00'} disabled={isPending} />
+          <Controller
+            name="endTime"
+            control={control}
+            render={({ field }) => (
+              <TimeCombobox value={field.value} onChange={field.onChange} disabled={isPending} error={errors.endTime?.message} />
+            )}
+          />
         </div>
 
         <div className="space-y-2">
           <Label>休憩開始</Label>
-          <TimeCombobox defaultValue={shift?.breakStartAt?.slice(11, 16) ?? '12:00'} disabled={isPending} />
+          <Controller
+            name="breakStartTime"
+            control={control}
+            render={({ field }) => (
+              <TimeCombobox value={field.value} onChange={field.onChange} disabled={isPending} error={errors.breakStartTime?.message} />
+            )}
+          />
         </div>
 
         <div className="space-y-2">
           <Label>休憩終了</Label>
-          <TimeCombobox defaultValue={shift?.breakEndAt?.slice(11, 16) ?? '13:00'} disabled={isPending} />
+          <Controller
+            name="breakEndTime"
+            control={control}
+            render={({ field }) => (
+              <TimeCombobox value={field.value} onChange={field.onChange} disabled={isPending} error={errors.breakEndTime?.message} />
+            )}
+          />
         </div>
       </div>
+
+      {errors.root && <p className="text-sm text-red-500">{errors.root.message}</p>}
 
       <div className="space-y-2">
         <Label htmlFor="shift-memo">メモ</Label>
         <Textarea
           id="shift-memo"
-          defaultValue={shift?.memo ?? ''}
+          {...register('memo')}
           placeholder="メモを入力（任意）"
           rows={4}
           disabled={isPending}
           className="resize-none"
         />
       </div>
-    </div>
+    </form>
   )
 }

--- a/src/features/shift/components/ShiftEditModal.tsx
+++ b/src/features/shift/components/ShiftEditModal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/dialog'
 import type { Shift } from '../types'
 import { ShiftEditForm } from './ShiftEditForm'
+import type { ShiftEditFormValues } from '../schemas/shiftEditSchema'
 
 type ShiftEditMode = 'create' | 'edit'
 
@@ -35,7 +36,8 @@ export function ShiftEditModal({
   const dateLabel = format(date, 'yyyy年M月d日（E）', { locale: ja })
 
   // TODO: シフト保存API接続タスクで実装
-  function handleSave() {
+  function handleFormSubmit(values: ShiftEditFormValues) {
+    console.log('ShiftEditForm submit:', values)
     onOpenChange(false)
   }
 
@@ -56,7 +58,7 @@ export function ShiftEditModal({
           </DialogDescription>
         </DialogHeader>
 
-        <ShiftEditForm shift={shift} isPending={isPending} />
+        <ShiftEditForm shift={shift} isPending={isPending} onSubmit={handleFormSubmit} />
 
         <DialogFooter className="flex justify-between sm:justify-between items-center">
           <div>
@@ -80,8 +82,9 @@ export function ShiftEditModal({
               キャンセル
             </Button>
             <Button
+              type="submit"
+              form="shift-edit-form"
               className="bg-blue-600 hover:bg-blue-700"
-              onClick={handleSave}
               disabled={isPending}
             >
               保存

--- a/src/features/shift/components/ShiftEditModal.tsx
+++ b/src/features/shift/components/ShiftEditModal.tsx
@@ -12,6 +12,7 @@ import {
 import type { Shift } from '../types'
 import { ShiftEditForm } from './ShiftEditForm'
 import type { ShiftEditFormValues } from '../schemas/shiftEditSchema'
+import { toShiftPayload } from '../utils/toShiftPayload'
 
 type ShiftEditMode = 'create' | 'edit'
 
@@ -37,7 +38,8 @@ export function ShiftEditModal({
 
   // TODO: シフト保存API接続タスクで実装
   function handleFormSubmit(values: ShiftEditFormValues) {
-    console.log('ShiftEditForm submit:', values)
+    const payload = toShiftPayload(values, date)
+    console.log('ShiftEditForm payload:', payload)
     onOpenChange(false)
   }
 

--- a/src/features/shift/components/ShiftEditModal.tsx
+++ b/src/features/shift/components/ShiftEditModal.tsx
@@ -1,8 +1,6 @@
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
 import { Button } from '@/components/ui/button'
-import { Label } from '@/components/ui/label'
-import { Textarea } from '@/components/ui/textarea'
 import {
   Dialog,
   DialogContent,
@@ -12,6 +10,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import type { Shift } from '../types'
+import { ShiftEditForm } from './ShiftEditForm'
 
 type ShiftEditMode = 'create' | 'edit'
 
@@ -57,19 +56,7 @@ export function ShiftEditModal({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-6 py-4">
-          <div className="space-y-2">
-            <Label htmlFor="shift-memo">メモ</Label>
-            <Textarea
-              id="shift-memo"
-              defaultValue={shift?.memo ?? ''}
-              placeholder="メモを入力（任意）"
-              rows={4}
-              
-              className="resize-none"
-            />
-          </div>
-        </div>
+        <ShiftEditForm shift={shift} isPending={isPending} />
 
         <DialogFooter className="flex justify-between sm:justify-between items-center">
           <div>

--- a/src/features/shift/hooks/usePositions.ts
+++ b/src/features/shift/hooks/usePositions.ts
@@ -1,0 +1,14 @@
+interface Position {
+  id: number
+  name: string
+}
+
+// Phase1: 静的リスト（設定API接続タスクで /api/v1/positions に差し替え）
+const POSITIONS: Position[] = [
+  { id: 1, name: 'ホール' },
+  { id: 2, name: 'キッチン' },
+]
+
+export function usePositions(): Position[] {
+  return POSITIONS
+}

--- a/src/features/shift/schemas/__tests__/shiftEditSchema.test.ts
+++ b/src/features/shift/schemas/__tests__/shiftEditSchema.test.ts
@@ -22,6 +22,32 @@ describe('shiftEditSchema', () => {
     expect(result.success).toBe(true)
   })
 
+  describe('休憩なし', () => {
+    it('休憩開始・休憩終了が両方空文字の場合バリデーション通過する', () => {
+      const result = shiftEditSchema.safeParse({ ...validInput, breakStartTime: '', breakEndTime: '' })
+      expect(result.success).toBe(true)
+    })
+
+    it('休憩なしの場合 breakStartTime / breakEndTime が undefined に変換される', () => {
+      const result = shiftEditSchema.safeParse({ ...validInput, breakStartTime: '', breakEndTime: '' })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.breakStartTime).toBeUndefined()
+        expect(result.data.breakEndTime).toBeUndefined()
+      }
+    })
+
+    it('休憩開始のみ入力した場合エラーになる', () => {
+      const error = getFieldError({ ...validInput, breakStartTime: '12:00', breakEndTime: '' }, 'breakStartTime')
+      expect(error).toBe('休憩開始と休憩終了は両方入力してください')
+    })
+
+    it('休憩終了のみ入力した場合エラーになる', () => {
+      const error = getFieldError({ ...validInput, breakStartTime: '', breakEndTime: '13:00' }, 'breakStartTime')
+      expect(error).toBe('休憩開始と休憩終了は両方入力してください')
+    })
+  })
+
   describe('退勤 vs 出勤', () => {
     it('退勤時間が出勤時間より前の場合エラーになる', () => {
       const error = getFieldError({ ...validInput, startTime: '18:00', endTime: '09:00' }, 'endTime')

--- a/src/features/shift/schemas/__tests__/shiftEditSchema.test.ts
+++ b/src/features/shift/schemas/__tests__/shiftEditSchema.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { shiftEditSchema } from '../shiftEditSchema'
+
+const validInput = {
+  positionId: '1',
+  startTime: '09:00',
+  endTime: '18:00',
+  breakStartTime: '12:00',
+  breakEndTime: '13:00',
+  memo: '',
+}
+
+function getFieldError(input: Record<string, string>, field: string): string | undefined {
+  const result = shiftEditSchema.safeParse(input)
+  if (result.success) return undefined
+  return result.error.issues.find((issue) => issue.path[0] === field)?.message
+}
+
+describe('shiftEditSchema', () => {
+  it('勤務時間・休憩時間がすべて正常な値でバリデーション通過する', () => {
+    const result = shiftEditSchema.safeParse(validInput)
+    expect(result.success).toBe(true)
+  })
+
+  describe('退勤 vs 出勤', () => {
+    it('退勤時間が出勤時間より前の場合エラーになる', () => {
+      const error = getFieldError({ ...validInput, startTime: '18:00', endTime: '09:00' }, 'endTime')
+      expect(error).toBe('退勤時間は出勤時間より後にしてください')
+    })
+
+    it('退勤時間と出勤時間が同じ場合エラーになる', () => {
+      const error = getFieldError({ ...validInput, startTime: '09:00', endTime: '09:00' }, 'endTime')
+      expect(error).toBe('退勤時間は出勤時間より後にしてください')
+    })
+  })
+
+  describe('休憩開始の範囲', () => {
+    it('休憩開始が出勤時間より前の場合エラーになる', () => {
+      const error = getFieldError({ ...validInput, startTime: '10:00', breakStartTime: '09:00' }, 'breakStartTime')
+      expect(error).toBe('休憩開始は勤務時間内にしてください')
+    })
+
+    it('休憩開始が退勤時間と同じ場合エラーになる', () => {
+      const error = getFieldError({ ...validInput, endTime: '18:00', breakStartTime: '18:00' }, 'breakStartTime')
+      expect(error).toBe('休憩開始は勤務時間内にしてください')
+    })
+  })
+
+  describe('休憩終了 vs 休憩開始', () => {
+    it('休憩終了が休憩開始と同じ場合エラーになる', () => {
+      const error = getFieldError({ ...validInput, breakStartTime: '12:00', breakEndTime: '12:00' }, 'breakEndTime')
+      expect(error).toBe('休憩終了は休憩開始より後にしてください')
+    })
+  })
+
+  describe('休憩終了 vs 退勤', () => {
+    it('休憩終了が退勤時間より後の場合エラーになる', () => {
+      const error = getFieldError({ ...validInput, endTime: '18:00', breakEndTime: '19:00' }, 'breakEndTime')
+      expect(error).toBe('休憩終了は退勤時間以前にしてください')
+    })
+  })
+})

--- a/src/features/shift/schemas/shiftEditSchema.ts
+++ b/src/features/shift/schemas/shiftEditSchema.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+
+const timePattern = /^\d{2}:\d{2}$/
+
+const timeField = z.string().regex(timePattern, '時刻を選択してください')
+
+export const shiftEditSchema = z
+  .object({
+    positionId: z.string().min(1, 'ポジションを選択してください'),
+    startTime: timeField,
+    endTime: timeField,
+    breakStartTime: timeField,
+    breakEndTime: timeField,
+    memo: z.string().optional(),
+  })
+  .refine((data) => data.endTime > data.startTime, {
+    message: '退勤時間は出勤時間より後にしてください',
+    path: ['endTime'],
+  })
+  .refine(
+    (data) =>
+      data.breakStartTime >= data.startTime &&
+      data.breakStartTime < data.endTime,
+    {
+      message: '休憩開始は勤務時間内にしてください',
+      path: ['breakStartTime'],
+    },
+  )
+  .refine((data) => data.breakEndTime > data.breakStartTime, {
+    message: '休憩終了は休憩開始より後にしてください',
+    path: ['breakEndTime'],
+  })
+  .refine(
+    (data) => data.breakEndTime <= data.endTime,
+    {
+      message: '休憩終了は退勤時間以前にしてください',
+      path: ['breakEndTime'],
+    },
+  )
+
+export type ShiftEditFormValues = z.infer<typeof shiftEditSchema>

--- a/src/features/shift/schemas/shiftEditSchema.ts
+++ b/src/features/shift/schemas/shiftEditSchema.ts
@@ -4,13 +4,17 @@ const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/
 
 const timeField = z.string().regex(TIME_PATTERN, '有効な時刻を入力してください')
 
+const optionalTimeField = timeField
+  .or(z.literal(''))
+  .transform((value) => (value === '' ? undefined : value))
+
 export const shiftEditSchema = z
   .object({
     positionId: z.string().min(1, 'ポジションを選択してください'),
     startTime: timeField,
     endTime: timeField,
-    breakStartTime: timeField,
-    breakEndTime: timeField,
+    breakStartTime: optionalTimeField,
+    breakEndTime: optionalTimeField,
     memo: z.string().optional(),
   })
   .refine((data) => data.endTime > data.startTime, {
@@ -19,24 +23,42 @@ export const shiftEditSchema = z
     abort: true,
   })
   .refine(
-    (data) =>
-      data.breakStartTime >= data.startTime &&
-      data.breakStartTime < data.endTime,
+    (data) => (data.breakStartTime === undefined) === (data.breakEndTime === undefined),
+    {
+      message: '休憩開始と休憩終了は両方入力してください',
+      path: ['breakStartTime'],
+    },
+  )
+  .refine(
+    (data) => {
+      if (!data.breakStartTime) return true
+      return data.breakStartTime >= data.startTime && data.breakStartTime < data.endTime
+    },
     {
       message: '休憩開始は勤務時間内にしてください',
       path: ['breakStartTime'],
     },
   )
-  .refine((data) => data.breakEndTime > data.breakStartTime, {
-    message: '休憩終了は休憩開始より後にしてください',
-    path: ['breakEndTime'],
-  })
   .refine(
-    (data) => data.breakEndTime <= data.endTime,
+    (data) => {
+      if (!data.breakStartTime || !data.breakEndTime) return true
+      return data.breakEndTime > data.breakStartTime
+    },
+    {
+      message: '休憩終了は休憩開始より後にしてください',
+      path: ['breakEndTime'],
+    },
+  )
+  .refine(
+    (data) => {
+      if (!data.breakEndTime) return true
+      return data.breakEndTime <= data.endTime
+    },
     {
       message: '休憩終了は退勤時間以前にしてください',
       path: ['breakEndTime'],
     },
   )
 
+export type ShiftEditFormInput = z.input<typeof shiftEditSchema>
 export type ShiftEditFormValues = z.infer<typeof shiftEditSchema>

--- a/src/features/shift/schemas/shiftEditSchema.ts
+++ b/src/features/shift/schemas/shiftEditSchema.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod'
 
-const timePattern = /^\d{2}:\d{2}$/
+const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/
 
-const timeField = z.string().regex(timePattern, '時刻を選択してください')
+const timeField = z.string().regex(TIME_PATTERN, '有効な時刻を入力してください')
 
 export const shiftEditSchema = z
   .object({

--- a/src/features/shift/schemas/shiftEditSchema.ts
+++ b/src/features/shift/schemas/shiftEditSchema.ts
@@ -16,6 +16,7 @@ export const shiftEditSchema = z
   .refine((data) => data.endTime > data.startTime, {
     message: '退勤時間は出勤時間より後にしてください',
     path: ['endTime'],
+    abort: true,
   })
   .refine(
     (data) =>

--- a/src/features/shift/types/index.ts
+++ b/src/features/shift/types/index.ts
@@ -25,8 +25,10 @@ export interface ApiShiftResponse {
   staff_id: number;
   start_at: string;
   end_at: string;
+  break_start_at: string | null;
+  break_end_at: string | null;
   shift_state: ShiftState;
-  position: { name: string } | null;
+  position: { id: number; name: string } | null;
   memo: string | null;
   staff_profile?: { name: string };
 }
@@ -36,7 +38,10 @@ export interface Shift {
   staffId: number;
   startAt: string;
   endAt: string;
+  breakStartAt?: string;
+  breakEndAt?: string;
   state: ShiftState;
+  positionId?: number;
   positionName?: string;
   memo?: string;
 }

--- a/src/features/shift/utils/__tests__/groupShiftsByStaffAndDate.test.ts
+++ b/src/features/shift/utils/__tests__/groupShiftsByStaffAndDate.test.ts
@@ -13,8 +13,8 @@ const makeShift = (id: number, staffId: number, startAt: string): Shift => ({
 describe('groupShiftsByStaffAndDate', () => {
   it('異なるスタッフのシフトが互いに干渉しない', () => {
     const shifts: Shift[] = [
-      makeShift(1, 1, '2026-05-01T00:00:00Z'),
-      makeShift(2, 2, '2026-05-01T00:00:00Z'),
+      makeShift(1, 1, '2026-05-01T09:00:00+09:00'),
+      makeShift(2, 2, '2026-05-01T09:00:00+09:00'),
     ]
 
     const result = groupShiftsByStaffAndDate(shifts)
@@ -27,8 +27,8 @@ describe('groupShiftsByStaffAndDate', () => {
 
   it('同一スタッフの異なる日付のシフトが別々のキーで管理される', () => {
     const shifts: Shift[] = [
-      makeShift(1, 1, '2026-05-01T00:00:00Z'),
-      makeShift(2, 1, '2026-05-02T00:00:00Z'),
+      makeShift(1, 1, '2026-05-01T09:00:00+09:00'),
+      makeShift(2, 1, '2026-05-02T09:00:00+09:00'),
     ]
 
     const result = groupShiftsByStaffAndDate(shifts)
@@ -42,8 +42,8 @@ describe('groupShiftsByStaffAndDate', () => {
   // 上書きが許されないパターン：1件でも欠落するとシフト確認業務に支障が出る
   it('同一スタッフ・同一日に複数シフトがある場合、すべて保持される', () => {
     const shifts: Shift[] = [
-      makeShift(1, 1, '2026-05-01T00:00:00Z'),
-      makeShift(2, 1, '2026-05-01T05:00:00Z'),
+      makeShift(1, 1, '2026-05-01T09:00:00+09:00'),
+      makeShift(2, 1, '2026-05-01T14:00:00+09:00'),
     ]
 
     const result = groupShiftsByStaffAndDate(shifts)
@@ -54,11 +54,10 @@ describe('groupShiftsByStaffAndDate', () => {
   })
 
   // タイムゾーンズレは全セルのシフト表示が消える致命的デグレになる
-  // "2026-04-30T15:00:00Z" は JST では 2026-05-01T00:00:00+09:00（日付をまたぐケース）
-  // TZ=Asia/Tokyo でテストを実行することを前提とする
-  it('UTC の startAt が JST のローカル日付キーに正しく変換される', () => {
+  // API は JST（+09:00）で返すため、日付キーは JST 基準で生成される
+  it('JST オフセット付きの startAt が正しい日付キーに変換される', () => {
     const shifts: Shift[] = [
-      makeShift(1, 1, '2026-04-30T15:00:00Z'),
+      makeShift(1, 1, '2026-05-01T00:00:00+09:00'),
     ]
 
     const result = groupShiftsByStaffAndDate(shifts)

--- a/src/features/shift/utils/__tests__/toShiftPayload.test.ts
+++ b/src/features/shift/utils/__tests__/toShiftPayload.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { toShiftPayload } from '../toShiftPayload'
+
+const validValues = {
+  positionId: '1',
+  startTime: '09:00',
+  endTime: '18:00',
+  breakStartTime: '12:00',
+  breakEndTime: '13:00',
+  memo: '早番',
+}
+
+describe('toShiftPayload', () => {
+  it('フォーム入力値と日付を結合して正しいペイロードに変換される', () => {
+    const date = new Date(2026, 3, 26)
+    const result = toShiftPayload(validValues, date)
+
+    expect(result).toEqual({
+      position_id: 1,
+      start_at: '2026-04-26T09:00:00',
+      end_at: '2026-04-26T18:00:00',
+      break_start_at: '2026-04-26T12:00:00',
+      break_end_at: '2026-04-26T13:00:00',
+      memo: '早番',
+    })
+  })
+
+  it('memo が空文字の場合 null に変換される', () => {
+    const date = new Date(2026, 3, 26)
+    const result = toShiftPayload({ ...validValues, memo: '' }, date)
+
+    expect(result.memo).toBeNull()
+  })
+
+  it('月末日で日付部分が正しく出力される', () => {
+    const date = new Date(2026, 0, 31)
+    const result = toShiftPayload(validValues, date)
+
+    expect(result.start_at).toBe('2026-01-31T09:00:00')
+    expect(result.end_at).toBe('2026-01-31T18:00:00')
+  })
+})

--- a/src/features/shift/utils/__tests__/toShiftPayload.test.ts
+++ b/src/features/shift/utils/__tests__/toShiftPayload.test.ts
@@ -32,6 +32,14 @@ describe('toShiftPayload', () => {
     expect(result.memo).toBeNull()
   })
 
+  it('休憩なし（undefined）の場合 break_start_at / break_end_at が null になる', () => {
+    const date = new Date(2026, 3, 26)
+    const result = toShiftPayload({ ...validValues, breakStartTime: undefined, breakEndTime: undefined }, date)
+
+    expect(result.break_start_at).toBeNull()
+    expect(result.break_end_at).toBeNull()
+  })
+
   it('月末日で日付部分が正しく出力される', () => {
     const date = new Date(2026, 0, 31)
     const result = toShiftPayload(validValues, date)

--- a/src/features/shift/utils/toShiftPayload.ts
+++ b/src/features/shift/utils/toShiftPayload.ts
@@ -1,0 +1,26 @@
+import { format } from 'date-fns'
+import type { ShiftEditFormValues } from '../schemas/shiftEditSchema'
+
+export interface ShiftPayload {
+  position_id: number
+  start_at: string
+  end_at: string
+  break_start_at: string
+  break_end_at: string
+  memo: string | null
+}
+
+function toDateTime(date: Date, time: string): string {
+  return `${format(date, 'yyyy-MM-dd')}T${time}:00`
+}
+
+export function toShiftPayload(values: ShiftEditFormValues, date: Date): ShiftPayload {
+  return {
+    position_id: Number(values.positionId),
+    start_at: toDateTime(date, values.startTime),
+    end_at: toDateTime(date, values.endTime),
+    break_start_at: toDateTime(date, values.breakStartTime),
+    break_end_at: toDateTime(date, values.breakEndTime),
+    memo: values.memo ? values.memo : null,
+  }
+}

--- a/src/features/shift/utils/toShiftPayload.ts
+++ b/src/features/shift/utils/toShiftPayload.ts
@@ -5,8 +5,8 @@ export interface ShiftPayload {
   position_id: number
   start_at: string
   end_at: string
-  break_start_at: string
-  break_end_at: string
+  break_start_at: string | null
+  break_end_at: string | null
   memo: string | null
 }
 
@@ -19,8 +19,8 @@ export function toShiftPayload(values: ShiftEditFormValues, date: Date): ShiftPa
     position_id: Number(values.positionId),
     start_at: toDateTime(date, values.startTime),
     end_at: toDateTime(date, values.endTime),
-    break_start_at: toDateTime(date, values.breakStartTime),
-    break_end_at: toDateTime(date, values.breakEndTime),
+    break_start_at: values.breakStartTime ? toDateTime(date, values.breakStartTime) : null,
+    break_end_at: values.breakEndTime ? toDateTime(date, values.breakEndTime) : null,
     memo: values.memo ? values.memo : null,
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,8 @@
   --color-accent-foreground: #ecfeff;
   --color-danger: #dc2626;
   --color-danger-foreground: #fef2f2;
+  --color-popover: #ffffff;
+  --color-popover-foreground: var(--color-foreground);
   --color-destructive: var(--color-danger);
   --color-destructive-foreground: var(--color-danger-foreground);
   --radius-sm: 0.25rem;


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

## 概要

シフト編集モーダルに時間入力フォーム（出退勤・休憩の時刻選択、ポジション選択、メモ入力）を実装し、React Hook Form + Zod によるバリデーションとフォーム送信値の ISO 8601 変換を追加した。

## 対象 変更内容

1. `ShiftEditForm` コンポーネント新規作成（base-ui Combobox による時刻選択、shadcn/ui Select によるポジション選択、メモ入力）
2. `shiftEditSchema`（Zod）によるフォームバリデーション（退勤＞出勤、休憩時間の範囲チェック等）とテスト
3. `toShiftPayload` によるフォーム値→APIペイロード変換（ISO 8601 形式）とテスト
4. `ShiftEditModal` から `ShiftEditForm` へのフォーム本体分離と `console.log` による送信値確認
5. テストデータのタイムゾーン表記を UTC（Z）から JST（+09:00）に統一

## 変更の目的

- シフトの登録・編集モーダルの実装
- モーダルで時刻入力UIを提供し、入力値のバリデーションと API 送信形式への変換を実行

## 動作確認

- [x] テスト実行済み（全 58 件パス）
- [x] TypeScript 型チェック通過
- [x] ローカル動作確認済み（時刻選択・ポジション選択・バリデーションエラー表示・console.log 出力）
- [x] 時刻 Combobox のテキストフィルタリング動作確認（コロンあり・なし両対応）