### PR TITLE
18.5〜18.7 AdminShiftsPageレイアウト・TopBar Figmaデザイン

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,27 @@
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+
+import { cn } from "@/lib/utils"
+import { CheckIcon } from "lucide-react"
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon
+        />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -17,8 +17,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
         data-slot="checkbox-indicator"
         className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
       >
-        <CheckIcon
-        />
+        <CheckIcon />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/src/features/shift/components/ShiftEditModal.tsx
+++ b/src/features/shift/components/ShiftEditModal.tsx
@@ -55,7 +55,7 @@ export function ShiftEditModal({
           <DialogTitle>
             {mode === 'create' ? 'シフトを登録' : 'シフトを編集'}
           </DialogTitle>
-          <DialogDescription className="text-gray-600">
+          <DialogDescription>
             {staffName} - {dateLabel}
           </DialogDescription>
         </DialogHeader>

--- a/src/features/shift/components/ShiftEditModal.tsx
+++ b/src/features/shift/components/ShiftEditModal.tsx
@@ -55,7 +55,7 @@ export function ShiftEditModal({
           <DialogTitle>
             {mode === 'create' ? 'シフトを登録' : 'シフトを編集'}
           </DialogTitle>
-          <DialogDescription>
+          <DialogDescription className="text-gray-600">
             {staffName} - {dateLabel}
           </DialogDescription>
         </DialogHeader>

--- a/src/features/shift/components/ShiftGrid.tsx
+++ b/src/features/shift/components/ShiftGrid.tsx
@@ -19,10 +19,11 @@ interface ShiftGridProps {
   members: Staff[]
   shifts: Shift[]
   closedDays?: DayOfWeek[]
+  showBalanceBar?: boolean
   onCellClick?: (cell: SelectedCell) => void
 }
 
-export function ShiftGrid({ dates, members, shifts, closedDays = [], onCellClick }: ShiftGridProps) {
+export function ShiftGrid({ dates, members, shifts, closedDays = [], showBalanceBar = true, onCellClick }: ShiftGridProps) {
   const gridTemplateColumns = `${STAFF_COL_WIDTH} repeat(${dates.length}, minmax(${DATE_COL_MIN_WIDTH}, 1fr))`
   const shiftMap = groupShiftsByStaffAndDate(shifts)
 
@@ -30,19 +31,21 @@ export function ShiftGrid({ dates, members, shifts, closedDays = [], onCellClick
     <div className="overflow-x-auto bg-gray-50">
       <div className="w-max min-w-full border-t border-l border-gray-200">
         <DateHeaderRow dates={dates} gridTemplateColumns={gridTemplateColumns} closedDays={closedDays} />
-        <div className="grid" style={{ gridTemplateColumns }}>
-          <div className="border-r-2 border-b border-gray-300 flex items-center px-3">
-            <span className="text-xs text-gray-500">必要人数</span>
-          </div>
-          {dates.map((cell, index) => (
-            <div key={cell.date.toISOString()} className="border-r border-b border-gray-200">
-              <BalanceBar
-                status={randomItem(DUMMY_BALANCE_STATUSES)}
-                diff={randomItem(DUMMY_BALANCE_DIFFS)}
-              />
+        {showBalanceBar && (
+          <div className="grid" style={{ gridTemplateColumns }}>
+            <div className="border-r-2 border-b border-gray-300 flex items-center px-3">
+              <span className="text-xs text-gray-500">必要人数</span>
             </div>
-          ))}
-        </div>
+            {dates.map((cell) => (
+              <div key={cell.date.toISOString()} className="border-r border-b border-gray-200">
+                <BalanceBar
+                  status={randomItem(DUMMY_BALANCE_STATUSES)}
+                  diff={randomItem(DUMMY_BALANCE_DIFFS)}
+                />
+              </div>
+            ))}
+          </div>
+        )}
         {members.map((member, index) => (
           <StaffRow
             key={member.id}

--- a/src/features/shift/components/TopBar.tsx
+++ b/src/features/shift/components/TopBar.tsx
@@ -1,0 +1,55 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { PeriodLabel } from './PeriodLabel'
+import type { ShiftPeriod } from '../types'
+
+interface TopBarProps {
+  period: ShiftPeriod
+  onPrev: () => void
+  onNext: () => void
+  onToday: () => void
+  showBalanceBar: boolean
+  onBalanceBarToggle: (value: boolean) => void
+}
+
+export function TopBar({
+  period,
+  onPrev,
+  onNext,
+  onToday,
+  showBalanceBar,
+  onBalanceBarToggle,
+}: TopBarProps) {
+  return (
+    <div className="bg-white border-b border-gray-200 px-6 py-4">
+      <div className="flex items-center justify-between gap-4">
+        <div />
+
+        <div className="flex items-center gap-3">
+          <Button variant="outline" size="icon" onClick={onPrev} aria-label="前の半月">
+            <ChevronLeft className="w-4 h-4" />
+          </Button>
+          <PeriodLabel period={period} />
+          <Button variant="outline" size="icon" onClick={onNext} aria-label="次の半月">
+            <ChevronRight className="w-4 h-4" />
+          </Button>
+          <Button variant="outline" onClick={onToday}>
+            今日
+          </Button>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="balance-bar"
+            checked={showBalanceBar}
+            onCheckedChange={(checked) => onBalanceBarToggle(checked === true)}
+          />
+          <label htmlFor="balance-bar" className="text-sm text-gray-700 cursor-pointer">
+            人員バランスバー
+          </label>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/shift/components/TopBar.tsx
+++ b/src/features/shift/components/TopBar.tsx
@@ -23,10 +23,10 @@ export function TopBar({
 }: TopBarProps) {
   return (
     <div className="bg-white border-b border-gray-200 px-6 py-4">
-      <div className="flex items-center justify-between gap-4">
-        <div />
+      <div className="flex items-center gap-4">
+        <div className="flex-1" />
 
-        <div className="flex items-center gap-3">
+        <div className="flex shrink-0 items-center gap-3">
           <Button variant="outline" size="icon" onClick={onPrev} aria-label="前の半月">
             <ChevronLeft className="w-4 h-4" />
           </Button>
@@ -39,7 +39,7 @@ export function TopBar({
           </Button>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-1 items-center justify-end gap-2">
           <Checkbox
             id="balance-bar"
             checked={showBalanceBar}

--- a/src/features/shift/components/TopBar.tsx
+++ b/src/features/shift/components/TopBar.tsx
@@ -43,7 +43,7 @@ export function TopBar({
           <Checkbox
             id="balance-bar"
             checked={showBalanceBar}
-            onCheckedChange={(checked) => onBalanceBarToggle(checked === true)}
+            onCheckedChange={onBalanceBarToggle}
           />
           <label htmlFor="balance-bar" className="text-sm text-gray-700 cursor-pointer">
             人員バランスバー

--- a/src/features/shift/hooks/usePeriodNavigation.ts
+++ b/src/features/shift/hooks/usePeriodNavigation.ts
@@ -52,6 +52,7 @@ export function usePeriodNavigation(initialPeriod: ShiftPeriod = getCurrentPerio
 
   const goToPrev = () => setPeriod((p) => getPrevPeriod(p))
   const goToNext = () => setPeriod((p) => getNextPeriod(p))
+  const goToToday = () => setPeriod(getCurrentPeriod())
 
-  return { period, goToPrev, goToNext }
+  return { period, goToPrev, goToNext, goToToday }
 }

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -44,11 +44,18 @@ export function AdminShiftsPage() {
         onBalanceBarToggle={setShowBalanceBar}
       />
 
-      <div className="flex-1 overflow-auto">
+      <div className="min-h-0 flex-1 overflow-auto">
         {isPending && <p className="text-center text-sm text-gray-500 py-8">読み込み中...</p>}
         {isError && <p className="text-center text-sm text-red-500 py-8">シフトの取得に失敗しました</p>}
         {!isPending && !isError && (
-          <ShiftGrid dates={dates} members={DUMMY_STAFF} shifts={shifts ?? []} closedDays={CLOSED_DAYS} showBalanceBar={showBalanceBar} onCellClick={handleCellClick} />
+          <ShiftGrid
+            dates={dates}
+            members={DUMMY_STAFF}
+            shifts={shifts ?? []}
+            closedDays={CLOSED_DAYS}
+            showBalanceBar={showBalanceBar}
+            onCellClick={handleCellClick}
+          />
         )}
       </div>
 

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -48,7 +48,7 @@ export function AdminShiftsPage() {
         {isPending && <p className="text-center text-sm text-gray-500 py-8">読み込み中...</p>}
         {isError && <p className="text-center text-sm text-red-500 py-8">シフトの取得に失敗しました</p>}
         {!isPending && !isError && (
-          <ShiftGrid dates={dates} members={DUMMY_STAFF} shifts={shifts ?? []} closedDays={CLOSED_DAYS} onCellClick={handleCellClick} />
+          <ShiftGrid dates={dates} members={DUMMY_STAFF} shifts={shifts ?? []} closedDays={CLOSED_DAYS} showBalanceBar={showBalanceBar} onCellClick={handleCellClick} />
         )}
       </div>
 

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -35,21 +35,29 @@ export function AdminShiftsPage() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-center gap-3">
-        <Button variant="outline" size="icon" onClick={goToPrev} aria-label="前の半月">
-          <ChevronLeft className="w-4 h-4" />
-        </Button>
-        <PeriodLabel period={period} />
-        <Button variant="outline" size="icon" onClick={goToNext} aria-label="次の半月">
-          <ChevronRight className="w-4 h-4" />
-        </Button>
+    <div className="flex flex-col h-full">
+      {/* TopBar エリア: 18.6 で TopBar コンポーネントに置き換え */}
+      <div className="bg-white border-b border-gray-200 px-6 py-4">
+        <div className="flex items-center justify-center gap-3">
+          <Button variant="outline" size="icon" onClick={goToPrev} aria-label="前の半月">
+            <ChevronLeft className="w-4 h-4" />
+          </Button>
+          <PeriodLabel period={period} />
+          <Button variant="outline" size="icon" onClick={goToNext} aria-label="次の半月">
+            <ChevronRight className="w-4 h-4" />
+          </Button>
+        </div>
       </div>
-      {isPending && <p className="text-center text-sm text-gray-500">読み込み中...</p>}
-      {isError && <p className="text-center text-sm text-red-500">シフトの取得に失敗しました</p>}
-      {!isPending && !isError && (
-        <ShiftGrid dates={dates} members={DUMMY_STAFF} shifts={shifts ?? []} closedDays={CLOSED_DAYS} onCellClick={handleCellClick} />
-      )}
+
+      {/* カレンダーエリア: 残りの高さを全て使い、溢れたらここだけスクロール */}
+      <div className="flex-1 overflow-auto">
+        {isPending && <p className="text-center text-sm text-gray-500 py-8">読み込み中...</p>}
+        {isError && <p className="text-center text-sm text-red-500 py-8">シフトの取得に失敗しました</p>}
+        {!isPending && !isError && (
+          <ShiftGrid dates={dates} members={DUMMY_STAFF} shifts={shifts ?? []} closedDays={CLOSED_DAYS} onCellClick={handleCellClick} />
+        )}
+      </div>
+
       {selectedCell && (
         <ShiftEditModal
           open={!!selectedCell}

--- a/src/pages/AdminShiftsPage.tsx
+++ b/src/pages/AdminShiftsPage.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { Button } from '../components/ui/button'
-import { PeriodLabel } from '../features/shift/components/PeriodLabel'
 import { ShiftEditModal } from '../features/shift/components/ShiftEditModal'
 import { ShiftGrid } from '../features/shift/components/ShiftGrid'
+import { TopBar } from '../features/shift/components/TopBar'
 import { useShifts } from '../features/shift/hooks/useShifts'
 import { usePeriodNavigation } from '../features/shift/hooks/usePeriodNavigation'
 import { generateDateRange } from '../features/shift/utils/generateDateRange'
@@ -21,10 +19,11 @@ const DUMMY_STAFF: Staff[] = [
 const CLOSED_DAYS: DayOfWeek[] = [0]
 
 export function AdminShiftsPage() {
-  const { period, goToPrev, goToNext } = usePeriodNavigation()
+  const { period, goToPrev, goToNext, goToToday } = usePeriodNavigation()
   const dates = generateDateRange(period)
   const { data: shifts, isPending, isError } = useShifts(period)
   const [selectedCell, setSelectedCell] = useState<SelectedCell | null>(null)
+  const [showBalanceBar, setShowBalanceBar] = useState(true)
 
   function handleCellClick(cell: SelectedCell) {
     setSelectedCell(cell)
@@ -36,20 +35,15 @@ export function AdminShiftsPage() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* TopBar エリア: 18.6 で TopBar コンポーネントに置き換え */}
-      <div className="bg-white border-b border-gray-200 px-6 py-4">
-        <div className="flex items-center justify-center gap-3">
-          <Button variant="outline" size="icon" onClick={goToPrev} aria-label="前の半月">
-            <ChevronLeft className="w-4 h-4" />
-          </Button>
-          <PeriodLabel period={period} />
-          <Button variant="outline" size="icon" onClick={goToNext} aria-label="次の半月">
-            <ChevronRight className="w-4 h-4" />
-          </Button>
-        </div>
-      </div>
+      <TopBar
+        period={period}
+        onPrev={goToPrev}
+        onNext={goToNext}
+        onToday={goToToday}
+        showBalanceBar={showBalanceBar}
+        onBalanceBarToggle={setShowBalanceBar}
+      />
 
-      {/* カレンダーエリア: 残りの高さを全て使い、溢れたらここだけスクロール */}
       <div className="flex-1 overflow-auto">
         {isPending && <p className="text-center text-sm text-gray-500 py-8">読み込み中...</p>}
         {isError && <p className="text-center text-sm text-red-500 py-8">シフトの取得に失敗しました</p>}


### PR DESCRIPTION
## 概要

シフト管理画面（AdminShiftsPage）のレイアウトを3段構造に変更し、TopBarコンポーネントを新規作成してシフト操作UIを整理しました。

## 変更内容

1. **AdminShiftsPageのレイアウトを3段構造に変更（18.5）**
   シフト管理画面はグリッドをスクロールしながら操作するため、日付ナビや操作ボタンが画面外に流れると操作不能になる。

   - **ルート要素**: `flex flex-col h-full` に変更し、親レイアウト（AdminLayout）の高さを使い切る構造に
   - **カレンダーエリア**: `flex-1 overflow-auto` で囲み、TopBar/BottomBar追加後もカレンダー部分だけがスクロールする構造を実現

2. **TopBarコンポーネントを新規作成（18.6）**
   日付ナビゲーション・フィルター類がページに散在すると責務が曖昧になるため、操作バーとして分離。

   - **日付ナビゲーション**: `justify-between` の3カラム構造で中央配置
   - **「今日」ボタン**: `usePeriodNavigation` に `goToToday` を追加し、現在の半月に即座に戻れる機能を実装
   - **BalanceBarトグル**: shadcn/ui Checkbox を導入し、人員バランスバーの表示/非表示を切り替え可能に

3. **ShiftEditModalのUIスタイル更新（18.7）**
   DialogDescription に `text-gray-600` を適用し、スタッフ名・日付の視認性を向上。

## 今回スコープ外

- **勤務区分ボタングループ（出勤/休み）**: 現時点では勤務時間未入力=休み扱いで判断可能。休み希望の登録はWeek10（タスク37〜39: 希望シフトDB設計・API・スタッフ側UI）で実装予定
- **TopBar右側フィルター群（グループ選択・希望シフト・確定シフト）**: バックエンドにフィルタリングAPIが未実装のためPhase1スコープ外
- **シフトパターンボタン（オープン/ラスト等）**: パターンマスタのAPI・データ設計が未定義のためPhase1スコープ外

## 動作確認

- [x] AdminShiftsPage: TopBar（日付ナビ・今日ボタン・BalanceBarトグル）が表示される
- [x] 「今日」ボタンクリックで現在の半月に戻る
- [x] BalanceBarトグルで人員バランスバーの表示/非表示が切り替わる
- [x] カレンダーエリアのみスクロールし、TopBarは固定される
- [x] セルクリックでShiftEditModalが開き、DialogDescriptionがグレーテキストで表示される
- [x] 他ページ（スタッフ管理・設定）のスクロールに影響がない